### PR TITLE
fixing rakefile to not error out on missing 10.8 SDK

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,9 +22,9 @@ directory DOWNLOAD_DIR
 directory WORKBENCH_DIR
 directory DEPENDENCIES_DESTROOT
 
-SDKROOT = File.join(`xcode-select -p`.strip, "Platforms/MacOSX.platform/Developer/SDKs/MacOSX#{DEPLOYMENT_TARGET}.sdk")
+SDKROOT = File.expand_path(`xcrun --show-sdk-path --sdk macosx`.strip)
 unless File.exist?(SDKROOT)
-  puts "[!] Unable to find the SDK for the deployment target `#{DEPLOYMENT_TARGET}` at `#{SDKROOT}`."
+  puts "[!] Unable to find a SDK for the Platform target `macosx`."
   exit 1
 end
 


### PR DESCRIPTION
fixing search path for default SDK when 10.8 SDK is not present. Deployment target doesn't rely on the base SDK of the target version being present. 

Note: There might be an edge-case if someone is building this that is below 10.8 as their default SDK target for the "macosx" platform.
