### PR TITLE
Fix typos

### DIFF
--- a/app/Podfile
+++ b/app/Podfile
@@ -1,6 +1,6 @@
 platform :osx, '10.8'
 
-# TODO inhibiting warnings (when they’re not harmfule) while working on the application.
+# TODO inhibiting warnings (when they're not harmful) while working on the application.
 
 # Has 3 warnings about deprecated -[NSImage setFlipped:] API
 pod 'Fragaria', :podspec => 'Fragaria.podspec.json', :inhibit_warnings => true


### PR DESCRIPTION
This change also silences a warning about smart quotes in the Podfile. As it turns out, the smart quotes were in a comment, where they wouldn’t affect anything, but CocoaPods warned about it nonetheless. This is now resolved.