### PR TITLE
Change install location for CLI tool

### DIFF
--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -1,7 +1,7 @@
 #import "CPAppDelegate.h"
 #import "CPCLIToolInstallationController.h"
 
-NSString * const kCPCLIToolSuggestedDestination = @"/usr/bin/pod";
+NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
 
 @interface CPAppDelegate ()
 @end


### PR DESCRIPTION
This change makes it possible to install the CLI tool on OS X El Capitan, where the System Integrity Protection feature renders `/usr/bin` unchangeable, even after acquiring root permissions via Authorization Services. See [here](http://asciiwwdc.com/2015/sessions/706) for details on SIP. Note that this change does not affect the “discoverability” of the CLI tool, as `/usr/local/bin` is on the OS X `PATH` by default.

This issue came up in the discussion around #52.