### PR TITLE
Wrap swizzling in dispatch_once()

### DIFF
--- a/app/CocoaPods/CPUserProject.m
+++ b/app/CocoaPods/CPUserProject.m
@@ -12,9 +12,12 @@
 
 + (void)load;
 {
-  Method m1 = class_getInstanceMethod(self, @selector(rangeForUserCompletion));
-  Method m2 = class_getInstanceMethod(self, @selector(CP_rangeForUserCompletion));
-  method_exchangeImplementations(m1, m2);
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    Method m1 = class_getInstanceMethod(self, @selector(rangeForUserCompletion));
+    Method m2 = class_getInstanceMethod(self, @selector(CP_rangeForUserCompletion));
+    method_exchangeImplementations(m1, m2);
+  });
 }
 
 -(NSRange)CP_rangeForUserCompletion;


### PR DESCRIPTION
This is a best practice recommended by the following blog post: <http://nshipster.com/method-swizzling/>

I would also recommend wrapping the swizzling code in an `@autoreleasepool`, but I don’t see how one is necessary here, seeing as how there wasn’t one before. Therefore, I omitted it to avoid a performance hit. If you disagree, please tell me and I’ll add one.