### PR TITLE
Yosemite Support

### DIFF
--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -499,6 +499,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "CocoaPods/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -512,6 +513,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "CocoaPods/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "CocoaPods/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -513,7 +513,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "CocoaPods/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/app/CocoaPods/CPCLIToolInstallationController.m
+++ b/app/CocoaPods/CPCLIToolInstallationController.m
@@ -66,7 +66,7 @@ NSString * const kCPCLIToolInstalledToDestinationsKey = @"CPCLIToolInstalledToDe
 static NSData *
 CPBookmarkDataForURL(NSURL *URL) {
   NSError *error = nil;
-  NSData *data = [URL bookmarkDataWithOptions:NSURLBookmarkCreationPreferFileIDResolution
+  NSData *data = [URL bookmarkDataWithOptions:0
                includingResourceValuesForKeys:nil
                                 relativeToURL:nil
                                         error:&error];

--- a/app/CocoaPods/CPUserProject.m
+++ b/app/CocoaPods/CPUserProject.m
@@ -101,11 +101,11 @@ typedef NSInteger NSModalResponse;
 - (void)presentProgressSheet;
 {
   NSWindowController *controller = self.windowControllers[0];
-  [NSApp beginSheet:self.progressWindow
-     modalForWindow:controller.window
-      modalDelegate:self
-     didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:)
-        contextInfo:NULL];
+  [controller.window beginSheet:self.progressWindow completionHandler:^(NSModalResponse returnCode) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self sheetDidEnd:self.progressWindow returnCode:returnCode contextInfo:NULL];
+    });
+  }];
 }
 
 - (void)sheetDidEnd:(NSWindow *)sheet


### PR DESCRIPTION
This PR changes the Xcode deployment target to 10.10, and removes usage of APIs marked as deprecated in that SDK. Note that, as OS X El Capitan is not yet released, I won’t prepare a PR including El Capitan-only APIs for some time. (However, if use of El Capitan APIs is required for #52 to be successfully completed, which is my overarching goal for CocoaPods-app, than so be it.)

I do not know of any reason you may have for keeping the deployment target set to OS X Mountain Lion, seeing as it is now two, soon to be three, releases out of date. However, if there is a reason that I don’t know about, please tell me and I will revise this PR.