### PR TITLE
Show a notification when pod install/update tasks complete. (Closes #83)

### DIFF
--- a/app/CocoaPods/CPUserProject.m
+++ b/app/CocoaPods/CPUserProject.m
@@ -242,7 +242,7 @@ typedef NSInteger NSModalResponse;
                                                 object:nil];
 
   NSUserNotification *completionNotification = [[NSUserNotification alloc] init];
-  completionNotification.title = @"Pod Workspace Ready";
+  completionNotification.title = NSLocalizedString(@"WORKSPACE_GENERATED_NOTIFICATION_TITLE", nil);
   completionNotification.subtitle = [[self.fileURL relativePath] stringByAbbreviatingWithTildeInPath];
   [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:completionNotification];
   

--- a/app/CocoaPods/CPUserProject.m
+++ b/app/CocoaPods/CPUserProject.m
@@ -241,6 +241,11 @@ typedef NSInteger NSModalResponse;
                                                   name:NSFileHandleDataAvailableNotification
                                                 object:nil];
 
+  NSUserNotification *completionNotification = [[NSUserNotification alloc] init];
+  completionNotification.title = @"Pod Workspace Ready";
+  completionNotification.subtitle = [[self.fileURL relativePath] stringByAbbreviatingWithTildeInPath];
+  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:completionNotification];
+  
   // Setting to `nil` signals through bindings that task has finished.
   self.task = nil;
 }

--- a/app/CocoaPods/Supporting Files/Localizable.strings
+++ b/app/CocoaPods/Supporting Files/Localizable.strings
@@ -8,4 +8,6 @@
 "INSTALL_CLI_WARNING_INFORMATIVE_TEXT" = "The tool was likely installed from the Terminal by running the “gem install cocoapods” command. If you wish to keep that installation intact, be sure to choose an alternate filename or directory (preferably in your Terminal PATH) for this tool.\n\nNote that you can always revert by running the aforementioned Terminal command again.";
 "INSTALL_CLI_WARNING_OVERWRITE" = "Overwrite";
 
+"WORKSPACE_GENERATED_NOTIFICATION_TITLE" = "Pod Workspace Ready";
+
 "CANCEL" = "Cancel";


### PR DESCRIPTION
Without an object to represent the NSTask (and what it actually
represents in CocoaPods terms), I didn’t want to introduce state to
remember what the actual operation (install or update) when it’s more
straightforward to refactor the NSTask logic into its own class that
can represent a named CP task.