### PR TITLE
Fixes a likely bad merge in CPUserProject.xib

### DIFF
--- a/app/CocoaPods/CPUserProject.xib
+++ b/app/CocoaPods/CPUserProject.xib
@@ -19,7 +19,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="133" y="235" width="507" height="413"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="800"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="gIp-Ho-8D9">
                 <rect key="frame" x="0.0" y="0.0" width="507" height="413"/>
@@ -93,7 +93,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="131" y="158" width="480" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="800"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="hlJ-d9-aN0">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -146,13 +146,13 @@ Gw
                             <binding destination="-2" name="title" keyPath="self.progressButtonTitle" id="DpO-jp-NWT"/>
                         </connections>
                     </button>
-                        <rect key="frame" x="20" y="20" width="362" height="20"/>
                     <progressIndicator wantsLayer="YES" misplaced="YES" maxValue="1" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="awf-Kn-Efq">
+                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="20"/>
                         <animations/>
                         <connections>
-                            <binding destination="-2" name="animate" keyPath="task.running" id="ibE-Av-nMH"/>
                             <binding destination="-2" name="isIndeterminate" keyPath="task.progress.indeterminate" previousBinding="ibE-Av-nMH" id="8fp-DH-ruh"/>
                             <binding destination="-2" name="toolTip" keyPath="task.progress.localizedDescription" id="Z8u-Yj-V6i"/>
+                            <binding destination="-2" name="animate" keyPath="task.running" id="ibE-Av-nMH"/>
                         </connections>
                     </progressIndicator>
                 </subviews>


### PR DESCRIPTION
The `rect` that is deleted was moved outside of a UIView subclass, andXcode wouldn't load. 