### PR TITLE
Show the home window on Dock icon click when no other windows are open

### DIFF
--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -32,6 +32,16 @@ NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
   }
 }
 
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)hasVisibleWindows
+{
+  // When the dock icon is clicked, show the home window if there are no other windows open
+  if (!hasVisibleWindows) {
+    [self showHomeWindow:sender];
+  }
+
+  return YES;
+}
+
 #pragma mark - Actions
 
 - (IBAction)installBinstubIfNecessary:(id)sender;


### PR DESCRIPTION
Home window shows up if the dock icon is clicked and no other windows are present, mimicking the behavior of Xcode’s welcome window.