### PR TITLE
[App/Ruby] Create underlying errors for Ruby exception causes.

### DIFF
--- a/app/CPReflectionService/CPReflectionService.m
+++ b/app/CPReflectionService/CPReflectionService.m
@@ -7,26 +7,14 @@
                  withReply:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable plugins, NSError * _Nullable error))reply;
 {
   [RBObject performBlock:^{
-    // It doesn’t really matter what we specify as path, as we’re not using the DSLError informative message.
+    // Use just `Podfile` as the path so that we can make assumptions about error messages
+    // and easily remove the path being mentioned.
     RBPathname *pathname = [RBObjectFromString(@"Pathname") new:@"Podfile"];
-    
-    @try {
-      RBPodfile *podfile = [RBObjectFromString(@"Pod::Podfile") from_ruby:pathname :contents];
-      NSArray *plugins = podfile.plugins.allKeys;
-      reply(plugins, nil);
-    }
-    
-    @catch (NSException *exception) {
-      // In case of a Pod::DSLError, try to create a UI syntax error out of it.
-      if (![exception.reason isEqualToString:@"Pod::DSLError"]) {
-        @throw;
-      }
-      RBException *rubyException = exception.userInfo[@"$!"];
-      RBException *cause = rubyException.cause;
-      NSError *error = CPErrorFromException(exception, cause.message);
-      reply(nil, error);
-    }
-    
+
+    RBPodfile *podfile = [RBObjectFromString(@"Pod::Podfile") from_ruby:pathname :contents];
+    NSArray *plugins = podfile.plugins.allKeys;
+    reply(plugins, nil);
+
   } error:^(NSError * _Nonnull error) {
     reply(nil, error);
   }];

--- a/app/CPReflectionService/CPRubyErrors.h
+++ b/app/CPReflectionService/CPRubyErrors.h
@@ -2,7 +2,6 @@
 
 extern NSString * _Nonnull const CPErrorDomain;
 extern NSString * _Nonnull const CPErrorName;
-extern NSString * _Nonnull const CPErrorCauseName;
 extern NSString * _Nonnull const CPErrorRubyBacktrace;
 extern NSString * _Nonnull const CPErrorObjCBacktrace;
 

--- a/app/CPReflectionService/CPRubyErrors.m
+++ b/app/CPReflectionService/CPRubyErrors.m
@@ -2,7 +2,6 @@
 
 NSString *const CPErrorDomain = @"org.cocoapods.app.ErrorDomain";
 NSString *const CPErrorName = @"exception-name";
-NSString *const CPErrorCauseName = @"exception-cause-name";
 NSString *const CPErrorRubyBacktrace = @"backtrace";
 NSString *const CPErrorObjCBacktrace = @"objc-backtrace";
 

--- a/app/CPReflectionService/RBObject+CocoaPods.m
+++ b/app/CPReflectionService/RBObject+CocoaPods.m
@@ -47,53 +47,77 @@ CPRubyInit(Class bundleClass)
 }
 
 
+#pragma mark - Conversions
+// Alas, RubyCocoa does not export the ocdata_conv.h header.
+// TODO If we need more polymorphic transforms in the future, see about making that header public.
+
+static NSString * _Nullable
+RBString(VALUE rb_string)
+{
+  return rb_string == Qnil ? nil : @(StringValuePtr(rb_string));
+}
+
+static NSArray<NSString *> * _Nonnull
+RBStringArray(VALUE rb_array)
+{
+  long size = RARRAY_LEN(rb_array);
+  NSMutableArray *array = [NSMutableArray arrayWithCapacity:size];
+  for (long i = 0; i < size; i++) {
+    [array addObject:RBString(rb_ary_entry(rb_array, i))];
+  }
+  return array;
+}
+
+
 #pragma mark - Errors
 
 NSError * _Nonnull
-CPErrorFromException(NSException * _Nonnull exception, NSString * _Nullable message)
+CPErrorFromRubyException(VALUE rb_exception, NSArray * _Nullable objcBacktrace)
 {
-  CPErrorDomainCode code = -1;
-
-  NSMutableDictionary *userInfo = [NSMutableDictionary new];
-  userInfo[CPErrorObjCBacktrace] = exception.callStackSymbols;
-  if (message) {
-    userInfo[NSLocalizedRecoverySuggestionErrorKey] = message;
+  CPErrorDomainCode code;
+  if (rb_obj_is_kind_of(rb_exception, rb_cPodInformativeError)) {
+    code = CPInformativeError;
+  } else {
+    code = CPStandardError;
   }
 
-  if ([exception.name hasPrefix:@"RBException_"]) {
-    VALUE rb_exception = [exception.userInfo[@"$!"] __rbobj__];
+  NSMutableDictionary *userInfo = [NSMutableDictionary new];
+  userInfo[NSLocalizedDescriptionKey] = @"Uncaught Ruby exception.";
+  userInfo[CPErrorName] = RBString(rb_class_name(rb_obj_class(rb_exception)));
+  userInfo[CPErrorRubyBacktrace] = RBStringArray(rb_funcall(rb_exception, rb_intern("backtrace"), 0));
 
-    VALUE exceptionNameValue = rb_class_name(rb_obj_class(rb_exception));
-    userInfo[CPErrorName] = @(StringValuePtr(exceptionNameValue));
-    VALUE rb_cause = rb_funcall(rb_exception, rb_intern("cause"), 0);
-    if (rb_cause != Qnil) {
-      exceptionNameValue = rb_class_name(rb_obj_class(rb_cause));
-      userInfo[CPErrorCauseName] = @(StringValuePtr(exceptionNameValue));
-    }
+  NSString *message = RBString(rb_funcall(rb_exception, rb_intern("message"), 0));
+  message = [message stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+  userInfo[NSLocalizedRecoverySuggestionErrorKey] = message;
 
-    userInfo[NSLocalizedDescriptionKey] = @"Uncaught Ruby exception.";
-    userInfo[CPErrorRubyBacktrace] = exception.userInfo[CPErrorRubyBacktrace];
+  if (objcBacktrace) {
+    userInfo[CPErrorObjCBacktrace] = objcBacktrace;
+  }
 
-    if (message == nil) {
-      if (rb_obj_is_kind_of(rb_exception, rb_cPodInformativeError)) {
-        code = CPInformativeError;
-      } else {
-        code = CPStandardError;
-      }
-      VALUE messageValue = rb_funcall(rb_exception, rb_intern("message"), 0);
-      messageValue = rb_funcall(messageValue, rb_intern("strip"), 0);
-      userInfo[NSLocalizedRecoverySuggestionErrorKey] = @(StringValuePtr(messageValue));
-    }
-
-  } else {
-    code = CPNonRubyError;
-    userInfo[CPErrorName] = exception.name;
-    userInfo[NSLocalizedDescriptionKey] = exception.reason;
+  VALUE rb_cause = rb_funcall(rb_exception, rb_intern("cause"), 0);
+  if (rb_cause != Qnil) {
+    userInfo[NSUnderlyingErrorKey] = CPErrorFromRubyException(rb_cause, nil);
   }
 
   return [NSError errorWithDomain:CPErrorDomain
                              code:code
                          userInfo:userInfo];
+}
+
+NSError * _Nonnull
+CPErrorFromException(NSException * _Nonnull exception, NSString * _Nullable message)
+{
+  if ([exception.name hasPrefix:@"RBException_"]) {
+    VALUE rb_exception = [exception.userInfo[@"$!"] __rbobj__];
+    return CPErrorFromRubyException(rb_exception, exception.callStackSymbols);
+  } else {
+    NSDictionary *userInfo = @{
+      NSLocalizedDescriptionKey: exception.reason,
+      CPErrorName: exception.name,
+      CPErrorObjCBacktrace: exception.callStackSymbols
+    };
+    return [NSError errorWithDomain:CPErrorDomain code:CPNonRubyError userInfo:userInfo];
+  }
 }
 
 static void

--- a/app/CocoaPods/CPPodfileReflection.m
+++ b/app/CocoaPods/CPPodfileReflection.m
@@ -65,11 +65,20 @@
 static SMLSyntaxError * _Nullable
 SyntaxErrorFromError(NSError * _Nonnull error)
 {
-  NSInteger lineNumber = -1;
-  NSString *description = error.localizedRecoverySuggestion;
+  // A Pod::DSLError only wraps the real exception and provides nicer output in the CLI.
+  // We want to retrieve information from the real exception.
+  if ([error.userInfo[CPErrorName] isEqualToString:@"Pod::DSLError"]) {
+    NSError *cause = error.userInfo[NSUnderlyingErrorKey];
+    if (cause) {
+      error = cause;
+    }
+  }
 
-  NSString *causeName = error.userInfo[CPErrorCauseName];
-  if (causeName && [causeName isEqualToString:@"SyntaxError"]) {
+  NSString *description = error.localizedRecoverySuggestion;
+  NSInteger lineNumber = -1;
+
+  // A SyntaxError shows the line at which the error occurs in its message, not in its backtrace.
+  if ([error.userInfo[CPErrorName] isEqualToString:@"SyntaxError"]) {
     // Example:
     //
     // Podfile:32: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
@@ -83,12 +92,17 @@ SyntaxErrorFromError(NSError * _Nonnull error)
     [scanner scanInteger:&lineNumber];
     [scanner scanString:@": " intoString:NULL];
     description = [description substringFromIndex:scanner.scanLocation];
+
   } else {
     NSString *location = [error.userInfo[CPErrorRubyBacktrace] firstObject];
-    if ([location componentsSeparatedByString:@":"].count < 2) { return nil; }
+    if ([location componentsSeparatedByString:@":"].count < 2) {
+      // Without a from from which to parse a line number, there is no point in showing an error in the UI.
+      return nil;
+    }
     lineNumber = [location componentsSeparatedByString:@":"][1].integerValue;
   }
 
+  // Capitalise the message.
   NSString *firstCharacter = [[description substringToIndex:1] uppercaseString];
   description = [firstCharacter stringByAppendingString:[description substringFromIndex:1]];
 


### PR DESCRIPTION
In reference to https://github.com/CocoaPods/CocoaPods-app/pull/129#discussion_r46500758

@segiddins :tophat::ok_hand: 