### PR TITLE
Register URL handler

### DIFF
--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		77356D751A2253F1002822CF /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 77356D741A2253F1002822CF /* Media.xcassets */; };
 		7C4B007D1B9B441800B6C782 /* CPANSIEscapeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */; };
 		BCB9AE8AEBBAE1D2D1441F62 /* Pods_CocoaPodsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 995F193B1C17F93F892E6798 /* Pods_CocoaPodsTests.framework */; };
+		FA16FAD21C144BF300DC3791 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16FAD11C144BF300DC3791 /* URLHandler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +211,7 @@
 		7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPANSIEscapeHelper.m; sourceTree = "<group>"; };
 		995F193B1C17F93F892E6798 /* Pods_CocoaPodsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPodsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C53A61848EA686BA6CCC6591 /* Pods-CocoaPodsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPodsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPodsTests/Pods-CocoaPodsTests.release.xcconfig"; sourceTree = "<group>"; };
+		FA16FAD11C144BF300DC3791 /* URLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -337,6 +339,7 @@
 				60FE01631B9B76470027EEE3 /* Podfile Window */,
 				60FE016D1B9B7F000027EEE3 /* Categories */,
 				60FE01621B9B76400027EEE3 /* Home Window */,
+				FA16FACB1C14475200DC3791 /* URL Handling */,
 				51165E221A17AFF500DCFC94 /* Supporting Files */,
 			);
 			path = CocoaPods;
@@ -495,6 +498,14 @@
 				C53A61848EA686BA6CCC6591 /* Pods-CocoaPodsTests.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		FA16FACB1C14475200DC3791 /* URL Handling */ = {
+			isa = PBXGroup;
+			children = (
+				FA16FAD11C144BF300DC3791 /* URLHandler.swift */,
+			);
+			path = "URL Handling";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -808,6 +819,7 @@
 				605119231C08F02D0037B95E /* CPBrownVisualEffectsView.swift in Sources */,
 				60FE01701B9B7F1E0027EEE3 /* SUUpdater+DebugMode.m in Sources */,
 				331188571BEBCB0F00272793 /* CPCLIToolInstallationController.m in Sources */,
+				FA16FAD21C144BF300DC3791 /* URLHandler.swift in Sources */,
 				51165E261A17AFF500DCFC94 /* CPAppDelegate.m in Sources */,
 				6051191D1C08A1EA0037B95E /* CPModifiedDecorationsWindow.swift in Sources */,
 				606D1ED51BF91040000B7148 /* CPPodfileEditorViewController.swift in Sources */,

--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -16,6 +16,11 @@ NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
 
 #pragma mark - NSApplicationDelegate
 
+- (void)applicationWillFinishLaunching:(NSNotification *)notification;
+{
+  [self startURLService];
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)notification;
 {
 #ifdef DEBUG
@@ -26,7 +31,6 @@ NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
 #endif
   
   [self startReflectionService];
-  [self startURLService];
 
   [[self CLIToolInstallationController] installBinstubIfNecessary];
 }

--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -2,12 +2,14 @@
 #import "CPCLIToolInstallationController.h"
 #import "CPHomeWindowController.h"
 #import "CPReflectionServiceProtocol.h"
+#import "CocoaPods-Swift.h"
 
 NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
 
 @interface CPAppDelegate ()
 @property (strong) CPHomeWindowController *homeWindowController;
 @property (strong) NSXPCConnection *reflectionService;
+@property (strong) URLHandler *urlHandler;
 @end
 
 @implementation CPAppDelegate
@@ -22,8 +24,9 @@ NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
   //[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"CPShowVerboseCommandOutput"];
   //NSLog(@"%@", [[NSUserDefaults standardUserDefaults] dictionaryRepresentation]);
 #endif
-
+  
   [self startReflectionService];
+  [self startURLService];
 
   [[self CLIToolInstallationController] installBinstubIfNecessary];
 }
@@ -35,6 +38,12 @@ NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
   self.reflectionService.invalidationHandler = ^{ NSLog(@"ReflectionService invalidated."); };
   self.reflectionService.interruptionHandler = ^{ NSLog(@"ReflectionService interrupted."); };
   [self.reflectionService resume];
+}
+
+- (void)startURLService;
+{
+  self.urlHandler = [URLHandler new];
+  [self.urlHandler registerHandler];
 }
 
 - (BOOL)applicationShouldOpenUntitledFile:(NSApplication *)sender

--- a/app/CocoaPods/Supporting Files/Info.plist
+++ b/app/CocoaPods/Supporting Files/Info.plist
@@ -59,6 +59,19 @@
 	<string>0.39.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>CocoaPods</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>cocoapods</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>0.39.0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/app/CocoaPods/URL Handling/URLHandler.swift
+++ b/app/CocoaPods/URL Handling/URLHandler.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Registers and handles the events related to opening the App via a custom URL.
+class URLHandler: NSObject {
+  
+  /// Registers itself has the handler for the URL events.
+  func registerHandler() {
+    
+    let eventClass = AEEventClass(kInternetEventClass)
+    let eventId = AEEventID(kAEGetURL)
+    
+    let manager = NSAppleEventManager.sharedAppleEventManager()
+    manager.setEventHandler(
+      self,
+      andSelector: "handleEvent:withReply:",
+      forEventClass: eventClass,
+      andEventID: eventId
+    )
+  }
+  
+  func handleEvent(event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
+    let key = AEKeyword(keyDirectObject)
+    let url = event.paramDescriptorForKeyword(key)?.stringValue
+    print("Handled URL: \(url)")
+  }
+  
+}
+


### PR DESCRIPTION
Hi everyone!
I took one of the *easy first step* issues and tried to fix it. This PR is related to #44. 

This should be only the first step into an appropriate URL handling feature, but at least now the App can be opened from an URL. I used `cocoapods://` as the URL scheme but if you want to use another just tell me. 

![captura de pantalla 2015-12-06 a las 11 23 09](https://cloud.githubusercontent.com/assets/750912/11613077/e8632f6e-9c0b-11e5-96e5-678cd6d7814c.png)

The installation is done in `applicationWillFinishLaunching` as as the [documentation recommends](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ScriptableCocoaApplications/SApps_handle_AEs/SAppsHandleAEs.html#//apple_ref/doc/uid/20001239-BBCIDFHG) and looks like is the best place in order to work with sandboxing.

I wrote it in Swift, as I'm presuming that this is the direction to go? If not just tell me, is easy enough to write it in Objective-C now that is a small piece of code. In fact it would have been easier xD It took me some minutes to figure out how to use the constants of some AE classes (AEEventClass) using the initializer. :joy: 

I've tried to be somewhat be consistent with your code style. Specially removing the generated comments on the top of the file. Any concerns feel free to comment. 

As a side note: When running the `rake app:prerequisites` I was having an error almost at the end of the process. I did some digging and looks like the problem was that I was using *ruby-2.2.1* with RVM. I then changed to use the system one  (on El Capitan) and everything worked. Maybe is worth it to add the required ruby version in the readme.