### PR TITLE
Posible fix for #130 (avoid errors delay in the editor)

### DIFF
--- a/app/CocoaPods/CPPodfileReflection.m
+++ b/app/CocoaPods/CPPodfileReflection.m
@@ -31,7 +31,18 @@
 - (void)textDidChange:(NSNotification *)notification;
 {
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(parsePodfile) object:nil];
-  [self performSelector:@selector(parsePodfile) withObject:nil afterDelay:0.5];
+  if ([self shouldParseImmediately]) {
+    [self parsePodfile];
+  } else {
+    [self performSelector:@selector(parsePodfile) withObject:nil afterDelay:0.5];
+  }
+}
+
+/// YES when the parsing should be updated immediatly.
+/// See https://github.com/CocoaPods/CocoaPods-app/issues/130
+- (BOOL)shouldParseImmediately
+{
+  return self.editor.syntaxErrors.count > 0;
 }
 
 - (void)parsePodfile;

--- a/app/CocoaPods/CPPodfileReflection.m
+++ b/app/CocoaPods/CPPodfileReflection.m
@@ -32,7 +32,7 @@
 {
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(parsePodfile) object:nil];
   if ([self shouldParseImmediately]) {
-    [self parsePodfile];
+    [self performSelector:@selector(parsePodfile) withObject:nil afterDelay:0.01];
   } else {
     [self performSelector:@selector(parsePodfile) withObject:nil afterDelay:0.5];
   }


### PR DESCRIPTION
This is the posible fix that I mentioned in #130. 

![error2](https://cloud.githubusercontent.com/assets/750912/11613285/413dc8f4-9c13-11e5-8aa7-0bf62bff6365.gif)*

*You can see how meanwhile an error is not detected the delay is present, but when there is an error the error moves immediately with the rest of the text.*
