### PR TITLE
Add IBAction to toggle comment to a text selection

### DIFF
--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9060"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -347,6 +346,12 @@
                                         </menuItem>
                                     </items>
                                 </menu>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="cTy-5d-3Sg"/>
+                            <menuItem title="Comment Selection" tag="1" keyEquivalent="/" id="7dI-nM-7NE">
+                                <connections>
+                                    <action selector="commentSelection:" target="-1" id="RPd-Au-yfT"/>
+                                </connections>
                             </menuItem>
                         </items>
                     </menu>

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -52,10 +52,11 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate {
   @IBAction func commentSelection(sender: NSMenuItem) {
     let selection = selectedLines(editor.textView)
     let processed = commentsInSelection(selection) ? removeCommentsFromLines(selection) : addCommentsInLines(selection)
-    // New line required
-    let newText = "\(processed.joinWithSeparator("\n"))\n"
 
-    editor.textView.textStorage?.replaceCharactersInRange(selectedLinesRange(editor.textView), withString: newText)
+    // Insert the new text by selecting the lines involved in the substitution
+    // A new line is required
+    editor.textView.setSelectedRange(selectedLinesRange(editor.textView))
+    editor.textView.insertText("\(processed.joinWithSeparator("\n"))\n")
   }
 
 }

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -50,13 +50,12 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate {
   }
 
   @IBAction func commentSelection(sender: NSMenuItem) {
-    guard let text = editor.textView.string else { return }
     let selection = selectedLines(editor.textView)
     let processed = commentsInSelection(selection) ? removeCommentsFromLines(selection) : addCommentsInLines(selection)
     // New line required
     let newText = "\(processed.joinWithSeparator("\n"))\n"
 
-    editor.textView.string = (text as NSString).stringByReplacingCharactersInRange(selectedLinesRange(editor.textView), withString: newText)
+    editor.textView.textStorage?.replaceCharactersInRange(selectedLinesRange(editor.textView), withString: newText)
   }
 
 }

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -51,21 +51,19 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate {
   }
 
   @IBAction func commentSelection(sender: NSMenuItem) {
-    let selection = selectedLines(editor.textView)
-    let shouldUncomment = commentsInSelection(selection)
-    let processed = shouldUncomment ? removeCommentsFromLines(selection) : addCommentsInLines(selection)
+    // Keep the cursor position to restore it later
     let cursorPosition = editor.textView.selectedRange().location + editor.textView.selectedRange().length
-      + (shouldUncomment ? -commentSyntax.characters.count : commentSyntax.characters.count)
+    let selection = selectedLines(editor.textView)
+    let processed = commentsInSelection(selection) ? removeCommentsFromLines(selection) : addCommentsInLines(selection)
+    let newText = "\(processed.joinWithSeparator("\n"))\n"
 
     // Insert the new text by selecting the lines involved in the substitution
-    // A new line is required
     editor.textView.setSelectedRange(selectedLinesRange(editor.textView))
-    editor.textView.insertText("\(processed.joinWithSeparator("\n"))\n")
+    let charDifference = (selectedLinesText(editor.textView)?.characters.count ?? 0) - newText.characters.count
+    editor.textView.insertText(newText)
 
-    // If a single line is commented, restore the cursor position in the same place
-    if processed.count == 1 {
-      editor.textView.setSelectedRange(NSMakeRange(cursorPosition, 0))
-    }
+    // Restore the cursor position in the same place
+    editor.textView.setSelectedRange(NSMakeRange(cursorPosition - charDifference, 0))
   }
 
 }


### PR DESCRIPTION
_This is a work in progress_  
 
I'm working on the ability to toggle comments in the Podfile editor as discussed in #113 

I've currently implemented a single IBAction in the `CPPodfileEditorViewController`. The text editing is provided by two extensions in the same file (`EditorSelection` and `Commenting`). These can be eventually be moved to keep the controller skinny (if you have suggestions, fire away), and can be probably reused in #112 

I provisionally added a menu item to simplify testing, this can be moved out of the way once #144 is resolved.

- [x] provide comment toggle
- [X] restore user's cursor position after the action
- [x] support undo
- [ ] move the menu option

