### PR TITLE
Add support for Podfile indentation 

### DIFF
--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -366,12 +366,12 @@
                                     <action selector="commentSelection:" target="-1" id="JLH-y1-1Rg"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Indent Selection" keyEquivalent="[" id="0eU-Ev-qUo">
+                            <menuItem title="Indent Selection" keyEquivalent="]" id="0eU-Ev-qUo">
                                 <connections>
                                     <action selector="indentSelection:" target="-1" id="VxH-cP-QwC"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Outdent Selection" keyEquivalent="]" id="cz4-yQ-iS8">
+                            <menuItem title="Outdent Selection" keyEquivalent="[" id="cz4-yQ-iS8">
                                 <connections>
                                     <action selector="outdentSelection:" target="-1" id="Cdl-5c-U2X"/>
                                 </connections>

--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -366,6 +366,16 @@
                                     <action selector="commentSelection:" target="-1" id="JLH-y1-1Rg"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Indent Selection" keyEquivalent="[" id="0eU-Ev-qUo">
+                                <connections>
+                                    <action selector="indentSelection:" target="-1" id="VxH-cP-QwC"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Outdent Selection" keyEquivalent="]" id="cz4-yQ-iS8">
+                                <connections>
+                                    <action selector="outdentSelection:" target="-1" id="Cdl-5c-U2X"/>
+                                </connections>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -70,7 +70,7 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate {
 
   /// Apply a text transformation to a selection
   ///
-  /// The trasnformation is provided as a closure. Returns an NSRange with the new selection, maintaining selected
+  /// The transformation is provided as a closure. Returns an NSRange with the new selection, maintaining selected
   /// the string selected by the user.
   /// - parameter change: the closure that accepts `[String]` and returns `[String]`
   /// - parameter selection: an array of Strings representing the lines of the selection

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -54,28 +54,47 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate {
   @IBAction func commentSelection(sender: NSMenuItem) {
     let selection = selectedLines(editor.textView)
     let change = commentsInSelection(selection) ? removeCommentsFromLines : addCommentsInLines
-    applyTextChange(change, toSelection: selection)
+    let range = applyTextChange(change, toSelection: selection)
+    editor.textView.setSelectedRange(NSMakeRange(range.location + range.length, 0))
   }
 
   @IBAction func indentSelection(sender: NSMenuItem) {
-    applyTextChange(indentedSelection, toSelection: selectedLines(editor.textView))
+    let range = applyTextChange(indentedSelection, toSelection: selectedLines(editor.textView))
+    editor.textView.setSelectedRange(range)
   }
 
   @IBAction func outdentSelection(sender: NSMenuItem) {
-    applyTextChange(outdentedSelection, toSelection: selectedLines(editor.textView))
+    let range = applyTextChange(outdentedSelection, toSelection: selectedLines(editor.textView))
+    editor.textView.setSelectedRange(range)
   }
 
-  private func applyTextChange(change: ([String] -> [String]), toSelection selection: [String]) {
-    // Keep the cursor position to restore it later
-    let cursorPosition = editor.textView.selectedRange().location + editor.textView.selectedRange().length
-    let newText = "\(change(selection).joinWithSeparator("\n"))\n"
+  /// Apply a text transformation to a selection
+  ///
+  /// The trasnformation is provided as a closure. Returns an NSRange with the new selection, maintaining selected
+  /// the string selected by the user.
+  /// - parameter change: the closure that accepts `[String]` and returns `[String]`
+  /// - parameter selection: an array of Strings representing the lines of the selection
+  /// - returns: NSRange
 
-    editor.textView.setSelectedRange(selectedLinesRange(editor.textView))
-    let charDifference = (selectedLinesText(editor.textView)?.characters.count ?? 0) - newText.characters.count
+  func applyTextChange(change: ([String] -> [String]), toSelection selection: [String]) -> NSRange {
+    let startingSelection = editor.textView.selectedRange()
+    let linesSelection = selectedLinesRange(editor.textView)
+    let processed = change(selection)
+    let newText = "\(processed.joinWithSeparator("\n"))\n"
+
+    editor.textView.setSelectedRange(linesSelection)
     editor.textView.insertText(newText)
 
-    // Restore the cursor position in the same place
-    editor.textView.setSelectedRange(NSMakeRange(cursorPosition - charDifference, 0))
+    // Restore the user's selection by calculating how the text moved
+    let charDifference = linesSelection.length - newText.characters.count
+
+    // Figure out how the first line (the starting location of the selection) moved
+    let firstLineChange = ((processed.first?.characters.count ?? 0) - (selection.first?.characters.count ?? 0))
+
+    // Return the new selection. Comparing the starting point with the absolute location of the first line 
+    // prevents the cursor from skipping back to the line above
+    return NSMakeRange(max(linesSelection.location, startingSelection.location + firstLineChange),
+      startingSelection.length - charDifference - firstLineChange)
   }
 
 }
@@ -85,17 +104,29 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate {
 typealias Indentation = CPPodfileEditorViewController
 extension Indentation {
 
+  /// Indents the selected text
+  ///
+  /// Adds two white spaces at the start of each line
+  /// - parameter lines: an array of strings representing the user's selection
+  /// - returns: [String]
+
   func indentedSelection(selection: [String]) -> [String] {
     return selection.map { line in
       return line.stringByReplacingCharactersInRange(Range(start: line.startIndex, end: line.startIndex), withString: indentationSyntax)
     }
   }
 
+  /// Outdents the current selection
+  ///
+  /// Removes either a single tab or a single string formed by one or two white spaces from the start of the lines
+  /// - parameter lines: an array of strings representing the user's selection
+  /// - returns: [String]
+
   func outdentedSelection(selection: [String]) -> [String] {
-    let indent = try! NSRegularExpression(pattern: "\t|^\\s{1,2}", options: .CaseInsensitive)
+    let indent = try! NSRegularExpression(pattern: "^\t|^\\s{1,2}", options: .CaseInsensitive)
     return selection.map { line in
       let firstMatch = indent.rangeOfFirstMatchInString(line, options: .Anchored, range: NSMakeRange(0, line.characters.count))
-      return (line as NSString).stringByReplacingCharactersInRange(firstMatch, withString: "")
+      return firstMatch.location != NSNotFound ? (line as NSString).stringByReplacingCharactersInRange(firstMatch, withString: "") : line
     }
   }
 


### PR DESCRIPTION
This covers #112 
The indent and outdent is provided with cmd-] and cmd-[ respectively.  
I was able to preserve the user's selection in the text. 

Here's how it works:

![screen capture on 2015-12-15 at 19-21-34](https://cloud.githubusercontent.com/assets/570797/11819625/279e0a80-a361-11e5-8fca-e951b671d3a6.gif)

As mentioned in #112 two white spaces are used as default.  
