### PR TITLE
Remembers window position

### DIFF
--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -90,10 +90,10 @@ NSString * const kCPCLIToolSuggestedDestination = @"/usr/local/bin/pod";
 {
   if (self.homeWindowController == nil) {
     self.homeWindowController = [[CPHomeWindowController alloc] init];
+    [self.homeWindowController.window center];
   }
 
   [self.homeWindowController showWindow:sender];
-  [self.homeWindowController.window center];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
This fixes #149.
Window will be centered on launch. It will remain at the same position after switching to another app.