### PR TITLE
Replace strange word ("forfil") in CPMiniPromiseDelegate method

### DIFF
--- a/app/CocoaPods/CPMiniPromise.h
+++ b/app/CocoaPods/CPMiniPromise.h
@@ -6,7 +6,7 @@
 /// and run the blocks.
 
 @protocol CPMiniPromiseDelegate <NSObject>
-- (BOOL)shouldForfilPromise:(CPMiniPromise *)promise;
+- (BOOL)shouldFulfillPromise:(CPMiniPromise *)promise;
 @end
 
 

--- a/app/CocoaPods/CPMiniPromise.m
+++ b/app/CocoaPods/CPMiniPromise.m
@@ -21,7 +21,7 @@
 
 - (BOOL)shouldSendCompletionBlocks
 {
-  return [self.delegate shouldForfilPromise:self];
+  return [self.delegate shouldFulfillPromise:self];
 }
 
 - (void)addBlock:(void (^)(void))block

--- a/app/CocoaPods/CPUserProject.m
+++ b/app/CocoaPods/CPUserProject.m
@@ -40,7 +40,7 @@
   return [self.contents writeToURL:absoluteURL atomically:YES encoding:NSUTF8StringEncoding error:outError];
 }
 
-- (BOOL)shouldForfilPromise:(CPMiniPromise *)promise
+- (BOOL)shouldFulfillPromise:(CPMiniPromise *)promise
 {
   return self.xcodeIntegrationDictionary && self.podfilePlugins;
 }


### PR DESCRIPTION
I was just reading the CPMiniPromise code when I read about it on twitter and noticed that gibberish method name that was probably unintentional. So I fixed it.