### PR TITLE
Update CPSpotlightDocumentSource's CPMiniPromiseDelegate conformity

### DIFF
--- a/app/CocoaPods/CPSpotlightDocumentSource.swift
+++ b/app/CocoaPods/CPSpotlightDocumentSource.swift
@@ -44,7 +44,7 @@ class CPSpotlightDocumentSource: NSObject, CPMiniPromiseDelegate {
     completedPromise.checkForFulfillment()
   }
 
-  func shouldForfilPromise(promise: CPMiniPromise!) -> Bool {
+  func shouldFulfillPromise(promise: CPMiniPromise!) -> Bool {
     return query.stopped
   }
 }


### PR DESCRIPTION
Corrects the method spelling from `shouldForfilPromise:` to `shouldFulfillPromise:` as per #203's change

Fixes #208