### PR TITLE
Add CPPodfileConsoleTextView to allow auto scrolling

### DIFF
--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		770382F41A2035B400435285 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 770382F31A2035B400435285 /* Localizable.strings */; };
 		77356D751A2253F1002822CF /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 77356D741A2253F1002822CF /* Media.xcassets */; };
 		7C4B007D1B9B441800B6C782 /* CPANSIEscapeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */; };
+		934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */; };
 		E70998471C49AB5B00229507 /* Podfile.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70998461C49AB5B00229507 /* Podfile.plist */; };
 		FA16FAD21C144BF300DC3791 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16FAD11C144BF300DC3791 /* URLHandler.swift */; };
 		FCDCC48F0E8CE099C20D1DEB /* Pods_CocoaPodsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62FB6E124C8280A7EBFD41C6 /* Pods_CocoaPodsTests.framework */; };
@@ -265,6 +266,7 @@
 		77356D741A2253F1002822CF /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		7C4B007B1B9B441800B6C782 /* CPANSIEscapeHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPANSIEscapeHelper.h; sourceTree = "<group>"; };
 		7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPANSIEscapeHelper.m; sourceTree = "<group>"; };
+		934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPPodfileConsoleTextView.swift; sourceTree = "<group>"; };
 		E70998461C49AB5B00229507 /* Podfile.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Podfile.plist; path = "Syntax Definitions/Podfile.plist"; sourceTree = "<group>"; };
 		EBD9373107B77CCDFCD43B67 /* Pods-CocoaPods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPods.release.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPods/Pods-CocoaPods.release.xcconfig"; sourceTree = "<group>"; };
 		EEB7DFACCFDF9B3B443AF311 /* Pods_CocoaPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -518,6 +520,7 @@
 				7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */,
 				60FE01661B9B7AA70027EEE3 /* SMLTextView+CocoaPods.m */,
 				605119241C08F5880037B95E /* CPFontAndColourGateKeeper.swift */,
+				934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */,
 			);
 			name = "Podfile Logging";
 			sourceTree = "<group>";
@@ -963,6 +966,7 @@
 				5EF5B7871C17990400F8C39E /* CPSideButton.swift in Sources */,
 				1F9177581BA27592006698C9 /* CPHomeWindowController.m in Sources */,
 				60E693A91C49B5980058DF5F /* CPSpotlightDocumentSource.swift in Sources */,
+				934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */,
 				6075BA671C06963700A5C491 /* CPInstallAction.swift in Sources */,
 				60E693B91C4A8DAD0058DF5F /* CPRecentDocumentSource.swift in Sources */,
 				3311885A1BEBCB4200272793 /* CPCLITask.m in Sources */,

--- a/app/CocoaPods/CPPodfileConsoleTextView.swift
+++ b/app/CocoaPods/CPPodfileConsoleTextView.swift
@@ -1,0 +1,30 @@
+import Cocoa
+
+class CPPodfileConsoleTextView: NSTextView {
+  
+  // We bind to `attributedText`, not `attributedString` in the storyboard, this is
+  // to allow us to calculate the previous scroll position before setting the new
+  // `attributedString` value which updates the text view
+  var attributedText: NSAttributedString? {
+    
+    didSet {
+      guard let attributedText = attributedText else { return }
+      
+      // Determine if we're at the tail of the output log (and should scroll) before we append more to it.
+      
+      let scrolledToBottom = NSMaxY(self.visibleRect) != NSMaxY(self.bounds)
+      
+      // Setting via `textStorage` as we cannot call `setAttributedString` directly
+      
+      self.textStorage?.setAttributedString(attributedText)
+      
+      // Keep the text view at the bottom if it was previously, otherwise restore the previous position.
+      
+      if (scrolledToBottom) {
+        self.scrollToEndOfDocument(self)
+      } else {
+        self.scrollPoint(self.visibleRect.origin)
+      }
+    }
+  }
+}

--- a/app/CocoaPods/CPPodfileConsoleViewController.swift
+++ b/app/CocoaPods/CPPodfileConsoleViewController.swift
@@ -11,26 +11,4 @@ class CPPodfileConsoleViewController: NSViewController, NSTextViewDelegate {
     let settings = CPFontAndColourGateKeeper()
     textView.font = settings.defaultFont;
   }
-
-  func textView(textView: NSTextView, willChangeSelectionFromCharacterRanges oldSelectedCharRanges: [NSValue], toCharacterRanges newSelectedCharRanges: [NSValue]) -> [NSValue] {
-
-    // Determine if we're at the tail of the output log (and should scroll) before we append more to it.
-
-    guard let scrollView = textView.enclosingScrollView else { return newSelectedCharRanges }
-
-    let visibleRect = scrollView.documentVisibleRect
-    let maxContentOffset = textView.bounds.size.height - visibleRect.size.height
-    let scrolledToBottom = visibleRect.origin.y == maxContentOffset
-
-    // Keep the text view at the bottom if it was previously, otherwise restore the previous position.
-
-    if (scrolledToBottom) {
-      textView.scrollToEndOfDocument(self)
-    } else {
-      textView.scrollPoint(visibleRect.origin)
-    }
-
-    return newSelectedCharRanges
-  }
-
 }

--- a/app/CocoaPods/Podfile.storyboard
+++ b/app/CocoaPods/Podfile.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D9c" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
@@ -368,7 +368,7 @@
                                     <nil key="backgroundColor"/>
                                 </clipView>
                                 <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="PHf-HC-OTM">
-                                    <rect key="frame" x="1" y="178" width="411" height="16"/>
+                                    <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="KRR-5W-Zmf">
@@ -807,7 +807,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="512" height="600"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textView editable="NO" importsGraphics="NO" richText="NO" selectionGranularity="word" findStyle="bar" incrementalSearchingEnabled="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" id="GuO-Ek-akK">
+                                        <textView editable="NO" importsGraphics="NO" richText="NO" selectionGranularity="word" findStyle="bar" incrementalSearchingEnabled="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" id="GuO-Ek-akK" customClass="CPPodfileConsoleTextView" customModule="CocoaPods" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="512" height="600"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -818,7 +818,7 @@ Gw
                                             <size key="maxSize" width="600" height="10000000"/>
                                             <connections>
                                                 <binding destination="hxh-b1-faZ" name="editable" keyPath="self.editable" id="rqN-Lz-pM6"/>
-                                                <binding destination="hxh-b1-faZ" name="attributedString" keyPath="self.podfileViewController.installAction.taskAttributedString" id="WmN-Em-YRx"/>
+                                                <binding destination="hxh-b1-faZ" name="attributedText" keyPath="self.podfileViewController.installAction.taskAttributedString" id="WmN-Em-YRx"/>
                                                 <outlet property="delegate" destination="hxh-b1-faZ" id="pDv-ms-8kF"/>
                                             </connections>
                                         </textView>


### PR DESCRIPTION
Fixes #188 by adding `CPPodfileConsoleTextView` to allow the text view to automatically scroll to the bottom if it was previously there. 

I attempted to do this scrolling via utilizing `NSTextView` delegate methods on `CPPodfileConsoleViewController` but none of them had the right order of completion. We must check current position, then append text and then scroll for this action to function correctly.

To do this, I have added an `attributedText` property to the `CPPodfileConsoleTextView` subclass (couldn't override `attributedString` directly). On `didSet` we check the current position then swap out the actual `attributedString` on the text storage and scroll to the previous positioning.

There may be a simpler way to do this than subclassing and adding a property but I couldn't work it out. If anyone has a suggestion on a cleaner way to implement this, I'm happy to give it a shot.