### PR TITLE
Metadata extraction for Metadata Table View

### DIFF
--- a/app/CocoaPods/CPMetadataTableViewDataSource.swift
+++ b/app/CocoaPods/CPMetadataTableViewDataSource.swift
@@ -1,97 +1,103 @@
 import Cocoa
 
-protocol XcodeProjectFlattenable {
-  func flattenForTargets(targets: [CPCocoaPodsTarget]) -> [AnyObject]
+protocol CPMetadataRepresentable: class {
+  var viewIdentifier: String { get }
+  var viewOwner: AnyObject? { get }
+  var rowHeight: CGFloat { get }
 }
 
-extension CPXcodeProject: XcodeProjectFlattenable {
-  func flattenForTargets(targets: [CPCocoaPodsTarget]) -> [AnyObject] {
-    return [self] + self.targets.flatMap { $0.flattenForTargets(targets) }
+extension CPXcodeProject: CPMetadataRepresentable {
+  var viewIdentifier: String { return "xcodeproject_metadata" }
+  var viewOwner: AnyObject? { return self }
+  var rowHeight: CGFloat { return 120 }
+}
+
+extension CPXcodeTarget: CPMetadataRepresentable {
+  var viewIdentifier: String { return "target_metadata" }
+  var viewOwner: AnyObject? { return self }
+  var rowHeight: CGFloat { return 150 }
+}
+
+extension CPPod: CPMetadataRepresentable {
+  var viewIdentifier: String { return "pod_metadata" }
+  var viewOwner: AnyObject? { return self }
+  var rowHeight: CGFloat { return 30 }
+}
+
+class Spacer: NSObject, CPMetadataRepresentable {
+  var viewIdentifier: String { return "spacer" }
+  var viewOwner: AnyObject? { return nil }
+  var rowHeight: CGFloat { return 30 }
+}
+
+protocol CPMetadataExtractable {
+  func metadataForTargets(targets: [CPCocoaPodsTarget]) -> [CPMetadataRepresentable]
+}
+
+extension CPXcodeProject: CPMetadataExtractable {
+  func metadataForTargets(targets: [CPCocoaPodsTarget]) -> [CPMetadataRepresentable] {
+    return [self] + self.targets.flatMap { $0.metadataForTargets(targets) }
   }
 }
 
-extension CPXcodeTarget: XcodeProjectFlattenable {
-  func flattenForTargets(targets: [CPCocoaPodsTarget]) -> [AnyObject] {
-    return [self] + cocoapodsTargets.flatMap { targetName -> [AnyObject] in
-      targets.filter { $0.name == targetName }.flatMap { $0.pods }
-    } + ["spacer"]
+extension CPXcodeTarget: CPMetadataExtractable {
+  func metadataForTargets(targets: [CPCocoaPodsTarget]) -> [CPMetadataRepresentable] {
+    let pods = cocoapodsTargets.flatMap { targetName -> [CPMetadataRepresentable] in
+      targets.filter { $0.name == targetName }
+        .flatMap { $0.pods }
+        .map { $0 as CPMetadataRepresentable }
+    }
+    
+    return [self as CPMetadataRepresentable] + pods + [Spacer() as CPMetadataRepresentable]
   }
 }
 
-extension Array where Element : XcodeProjectFlattenable {
-  func flattenForTargets(targets: [CPCocoaPodsTarget]) -> [AnyObject] {
-    return flatMap { element -> [AnyObject] in
-      return (element as XcodeProjectFlattenable).flattenForTargets(targets)
+extension Array where Element : CPMetadataExtractable {
+  func metadataForTargets(targets: [CPCocoaPodsTarget]) -> [CPMetadataRepresentable] {
+    return flatMap { element -> [CPMetadataRepresentable] in
+      return (element as CPMetadataExtractable).metadataForTargets(targets)
     }
   }
 }
 
-
 class CPMetadataTableViewDataSource: NSObject, NSTableViewDataSource, NSTableViewDelegate {
 
-  var flattenedXcodeProject: [AnyObject] = []
+  var projectMetadataEntries: [CPMetadataRepresentable] = [] {
+    didSet {
+      tableView.reloadData()
+    }
+  }
+  
   var plugins = ["No plugins"]
 
   @IBOutlet weak var tableView: NSTableView!
 
   func setXcodeProjects(projects:[CPXcodeProject], targets:[CPCocoaPodsTarget]) {
-    flattenedXcodeProject = flattenXcodeProjects(projects, targets:targets)
-    tableView.reloadData()
+    projectMetadataEntries = projects.metadataForTargets(targets)
   }
 
-  private func flattenXcodeProjects(projects:[CPXcodeProject], targets:[CPCocoaPodsTarget]) -> [AnyObject] {
-    return projects.flattenForTargets(targets)
-  }
-  
   // Nothing is selectable except the buttons
   func tableView(tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
     return false
   }
 
   func numberOfRowsInTableView(tableView: NSTableView) -> Int {
-    return flattenedXcodeProject.count
+    return projectMetadataEntries.count
   }
 
   // Allows the UI to be set up via bindings
   func tableView(tableView: NSTableView, objectValueForTableColumn tableColumn: NSTableColumn?, row: Int) -> AnyObject? {
-    return flattenedXcodeProject[row]
+    return projectMetadataEntries[row]
   }
 
   func tableView(tableView: NSTableView, viewForTableColumn tableColumn: NSTableColumn?, row: Int) -> NSView? {
-    let data = flattenedXcodeProject[row]
-    if let xcodeproj = data as? CPXcodeProject {
-      return tableView.makeViewWithIdentifier("xcodeproject_metadata", owner: xcodeproj)
-
-    } else if let target = data as? CPXcodeTarget {
-      return tableView.makeViewWithIdentifier("target_metadata", owner: target)
-
-    } else if let pod = data as? CPPod {
-      return tableView.makeViewWithIdentifier("pod_metadata", owner: pod)
-
-    } else if let _ = data as? NSString {
-      return tableView.makeViewWithIdentifier("spacer", owner: nil)
-    }
-
-    print("Should not have data unaccounted for in the flattened xcode project");
-    return nil
+    let data = projectMetadataEntries[row]
+    
+    return tableView.makeViewWithIdentifier(data.viewIdentifier,
+      owner: data.viewOwner)
   }
 
   func tableView(tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-    let data = flattenedXcodeProject[row]
-    if let _ = data as? CPXcodeProject {
-      return 120
-
-    } else if let _ = data as? CPXcodeTarget {
-      return 150
-
-    } else if let _ = data as? CPPod {
-      return 30
-
-    // Spacer
-    } else if let _ = data as? NSString {
-      return 30
-    }
-
-    return 0
+    return projectMetadataEntries[row].rowHeight
   }
 }


### PR DESCRIPTION
This started as an exercise to code-golf `flattenXcodeProjects(_:targets:)` after being poked by @nwest. I got this far:

```Swift
private func flattenXcodeProjects(projects:[CPXcodeProject], targets:[CPCocoaPodsTarget]) -> [AnyObject] {
  return projects.flatMap { project in
    [project] + project.targets.flatMap { target -> [AnyObject] in
      let pods = target.cocoapodsTargets.flatMap { targetName in
        targets.filter { $0.name == targetName }.flatMap { $0.pods }
      } as [AnyObject]
      
      return [target] + pods + ["spacer"]
    }
  }
}
```

The more I used it, though, the more I realized that there are two things happening in this file: converting from a list of Xcode projects and a list of CocoaPods targets to an array of entries to display in a table view, and displaying metadata from that list to display in the table. Both of those tasks seemed well-suited to protocols. So, this PR creates two protocols: `CPMetadataExtractable`, which covers converting the two arrays into one array of metadata, and `CPMetadataRepresentable`, which covers displaying the data in the table.

This is a pretty big change, but it buys more type safety. Notice that `tableView(_:heightOfRow:)` and `tableView(_: viewForTableColumn:row:)` no longer need to handle the “else” case of displaying nothing, since the array of `projectMetadataEntries` is type-safe.

Overall, in exchange for a net gain of 14 lines, we’ve gained a lot of safety. I think it’s a net positive.