### PR TITLE
Add notifications for recent and newly opened files, using them to up…

### DIFF
--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		7C4B007D1B9B441800B6C782 /* CPANSIEscapeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */; };
 		934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */; };
 		934FF1891C4F1E2A000B4302 /* CPDocumentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */; };
+		93FB07E11C503572007B2CDA /* CPDocumentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FB07E01C503572007B2CDA /* CPDocumentSource.swift */; };
 		E70998471C49AB5B00229507 /* Podfile.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70998461C49AB5B00229507 /* Podfile.plist */; };
 		FA16FAD21C144BF300DC3791 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16FAD11C144BF300DC3791 /* URLHandler.swift */; };
 		FCDCC48F0E8CE099C20D1DEB /* Pods_CocoaPodsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62FB6E124C8280A7EBFD41C6 /* Pods_CocoaPodsTests.framework */; };
@@ -271,6 +272,7 @@
 		7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPANSIEscapeHelper.m; sourceTree = "<group>"; };
 		934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPPodfileConsoleTextView.swift; sourceTree = "<group>"; };
 		934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPDocumentController.swift; sourceTree = "<group>"; };
+		93FB07E01C503572007B2CDA /* CPDocumentSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPDocumentSource.swift; sourceTree = "<group>"; };
 		E70998461C49AB5B00229507 /* Podfile.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Podfile.plist; path = "Syntax Definitions/Podfile.plist"; sourceTree = "<group>"; };
 		EBD9373107B77CCDFCD43B67 /* Pods-CocoaPods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPods.release.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPods/Pods-CocoaPods.release.xcconfig"; sourceTree = "<group>"; };
 		EEB7DFACCFDF9B3B443AF311 /* Pods_CocoaPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -572,6 +574,7 @@
 				1F91775C1BA27598006698C9 /* CPHomeWindowController.xib */,
 				60E693A81C49B5980058DF5F /* CPSpotlightDocumentSource.swift */,
 				60E693B81C4A8DAD0058DF5F /* CPRecentDocumentSource.swift */,
+				93FB07E01C503572007B2CDA /* CPDocumentSource.swift */,
 				60E693B41C4A71E50058DF5F /* CPSidebarDocumentsController.swift */,
 				934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */,
 			);
@@ -970,6 +973,7 @@
 				51165E281A17AFF500DCFC94 /* main.m in Sources */,
 				601ACAA31C389E9B0058FA86 /* CPXcodeInformationGenerator.m in Sources */,
 				5EF5B7871C17990400F8C39E /* CPSideButton.swift in Sources */,
+				93FB07E11C503572007B2CDA /* CPDocumentSource.swift in Sources */,
 				1F9177581BA27592006698C9 /* CPHomeWindowController.m in Sources */,
 				60E693A91C49B5980058DF5F /* CPSpotlightDocumentSource.swift in Sources */,
 				934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */,

--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		77356D751A2253F1002822CF /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 77356D741A2253F1002822CF /* Media.xcassets */; };
 		7C4B007D1B9B441800B6C782 /* CPANSIEscapeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */; };
 		934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */; };
+		934FF1891C4F1E2A000B4302 /* CPDocumentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */; };
 		E70998471C49AB5B00229507 /* Podfile.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70998461C49AB5B00229507 /* Podfile.plist */; };
 		FA16FAD21C144BF300DC3791 /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA16FAD11C144BF300DC3791 /* URLHandler.swift */; };
 		FCDCC48F0E8CE099C20D1DEB /* Pods_CocoaPodsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 62FB6E124C8280A7EBFD41C6 /* Pods_CocoaPodsTests.framework */; };
@@ -269,6 +270,7 @@
 		7C4B007B1B9B441800B6C782 /* CPANSIEscapeHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPANSIEscapeHelper.h; sourceTree = "<group>"; };
 		7C4B007C1B9B441800B6C782 /* CPANSIEscapeHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPANSIEscapeHelper.m; sourceTree = "<group>"; };
 		934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPPodfileConsoleTextView.swift; sourceTree = "<group>"; };
+		934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPDocumentController.swift; sourceTree = "<group>"; };
 		E70998461C49AB5B00229507 /* Podfile.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Podfile.plist; path = "Syntax Definitions/Podfile.plist"; sourceTree = "<group>"; };
 		EBD9373107B77CCDFCD43B67 /* Pods-CocoaPods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CocoaPods.release.xcconfig"; path = "Pods/Target Support Files/Pods-CocoaPods/Pods-CocoaPods.release.xcconfig"; sourceTree = "<group>"; };
 		EEB7DFACCFDF9B3B443AF311 /* Pods_CocoaPods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CocoaPods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -571,6 +573,7 @@
 				60E693A81C49B5980058DF5F /* CPSpotlightDocumentSource.swift */,
 				60E693B81C4A8DAD0058DF5F /* CPRecentDocumentSource.swift */,
 				60E693B41C4A71E50058DF5F /* CPSidebarDocumentsController.swift */,
+				934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */,
 			);
 			name = "Home Window";
 			sourceTree = "<group>";
@@ -977,6 +980,7 @@
 				60814A8A1C2C420600D6663E /* CPInterfaceBuilderOnlyLabels.swift in Sources */,
 				601F91151BE6435E00AD22B1 /* NSURL+TersePaths.m in Sources */,
 				66F2E29C1C492C5500A1AF1F /* NSColor+CPColors.m in Sources */,
+				934FF1891C4F1E2A000B4302 /* CPDocumentController.swift in Sources */,
 				60E693B31C4A561E0058DF5F /* CPThickDecorationsWindow.swift in Sources */,
 				60E693BD1C4AC6390058DF5F /* CPHomeSidebarButton.swift in Sources */,
 				605119231C08F02D0037B95E /* CPBrownVisualEffectsView.swift in Sources */,

--- a/app/CocoaPods/Base.lproj/CPHomeWindowController.xib
+++ b/app/CocoaPods/Base.lproj/CPHomeWindowController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15D9c" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
@@ -23,7 +23,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" texturedBackground="YES" unifiedTitleAndToolbar="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="665" height="490"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="800"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2880" height="1597"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="665" height="490"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -34,22 +34,6 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="FP0-mA-dMU">
                                 <rect key="frame" x="0.0" y="460" width="233" height="36"/>
                                 <subviews>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UXQ-ah-FzE" customClass="CPHomeSidebarButton" customModule="CocoaPods" customModuleProvider="target">
-                                        <rect key="frame" x="119" y="0.0" width="64" height="36"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="36" id="0xs-Iz-sHf"/>
-                                            <constraint firstAttribute="width" constant="64" id="N7l-o4-iu8"/>
-                                        </constraints>
-                                        <buttonCell key="cell" type="bevel" title="Spotlight" bezelStyle="rounded" alignment="center" state="on" imageScaling="proportionallyDown" inset="2" id="cBv-G6-wqj">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                            <string key="keyEquivalent">2</string>
-                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                                        </buttonCell>
-                                        <connections>
-                                            <action selector="spotlightButtonTapped:" target="Whb-bK-is0" id="wkQ-KE-rzI"/>
-                                        </connections>
-                                    </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3dY-gu-lGh" customClass="CPHomeSidebarButton" customModule="CocoaPods" customModuleProvider="target">
                                         <rect key="frame" x="44" y="0.0" width="69" height="36"/>
                                         <constraints>
@@ -57,13 +41,29 @@
                                             <constraint firstAttribute="width" constant="69" id="XTB-Da-zeW"/>
                                         </constraints>
                                         <buttonCell key="cell" type="bevel" title="Recent" bezelStyle="rounded" alignment="center" state="on" imageScaling="proportionallyDown" inset="2" id="cK3-dR-BDB">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                             <string key="keyEquivalent">1</string>
                                             <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="recentButtonTapped:" target="Whb-bK-is0" id="hnb-Y9-Dxe"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UXQ-ah-FzE" customClass="CPHomeSidebarButton" customModule="CocoaPods" customModuleProvider="target">
+                                        <rect key="frame" x="121" y="0.0" width="64" height="36"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="36" id="0xs-Iz-sHf"/>
+                                            <constraint firstAttribute="width" constant="64" id="N7l-o4-iu8"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="bevel" title="Spotlight" bezelStyle="rounded" alignment="center" truncatesLastVisibleLine="YES" state="on" imageScaling="proportionallyDown" inset="2" id="cBv-G6-wqj">
+                                            <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                            <string key="keyEquivalent">2</string>
+                                            <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="spotlightButtonTapped:" target="Whb-bK-is0" id="wkQ-KE-rzI"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -268,8 +268,16 @@
             </connections>
             <point key="canvasLocation" x="528.5" y="415"/>
         </window>
-        <customObject id="4vU-Cg-0pp" customClass="CPSpotlightDocumentSource" customModule="CocoaPods" customModuleProvider="target"/>
-        <customObject id="vg8-5r-eb7" customClass="CPRecentDocumentSource" customModule="CocoaPods" customModuleProvider="target"/>
+        <customObject id="4vU-Cg-0pp" customClass="CPSpotlightDocumentSource" customModule="CocoaPods" customModuleProvider="target">
+            <connections>
+                <outlet property="delegate" destination="Whb-bK-is0" id="AWY-Np-VKj"/>
+            </connections>
+        </customObject>
+        <customObject id="vg8-5r-eb7" customClass="CPRecentDocumentSource" customModule="CocoaPods" customModuleProvider="target">
+            <connections>
+                <outlet property="delegate" destination="Whb-bK-is0" id="rO1-dG-fS6"/>
+            </connections>
+        </customObject>
         <customObject id="TsL-KI-RcJ" customClass="CPExternalLinksHelper"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="3g8-qK-y7T" customClass="BlueView" customModule="CocoaPods" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="432" height="474"/>
@@ -401,7 +409,7 @@ Command-Line Tools?</string>
             </constraints>
             <point key="canvasLocation" x="-145" y="423"/>
         </customView>
-        <customObject id="Whb-bK-is0" customClass="CPSidebarDocumentsController" customModule="CocoaPods" customModuleProvider="target">
+        <customObject id="Whb-bK-is0" userLabel="Sidebar Documents Controller" customClass="CPSidebarDocumentsController" customModule="CocoaPods" customModuleProvider="target">
             <connections>
                 <outlet property="documentScrollView" destination="3Jq-7y-btG" id="apo-m5-pVe"/>
                 <outlet property="openPodfileView" destination="qtI-Qc-skM" id="JM2-tN-Ixs"/>

--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15D9c" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
@@ -11,7 +11,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="CPAppDelegate"/>
+        <customObject id="Voe-Tx-rLC" customClass="CPAppDelegate">
+            <connections>
+                <outlet property="documentController" destination="Qtz-kf-riq" id="Zl6-hS-hbl"/>
+            </connections>
+        </customObject>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <customObject id="Byb-Tq-L28" customClass="SUUpdater"/>
         <customObject id="bzE-zY-Vxb" customClass="CPExternalLinksHelper"/>
@@ -84,7 +88,7 @@
                         <items>
                             <menuItem title="Open Podfile…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
-                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                    <action selector="openDocument:" target="Qtz-kf-riq" id="uid-Xs-MhY"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Open Recent Podfile" id="tXI-mr-wws">
@@ -94,7 +98,7 @@
                                         <menuItem title="Clear Menu" id="vNY-rz-j42">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
-                                                <action selector="clearRecentDocuments:" target="-1" id="Daa-9d-B3U"/>
+                                                <action selector="clearRecentDocuments:" target="Qtz-kf-riq" id="qqL-IW-wBR"/>
                                             </connections>
                                         </menuItem>
                                     </items>
@@ -497,5 +501,6 @@
                 </menuItem>
             </items>
         </menu>
+        <customObject id="Qtz-kf-riq" customClass="CPDocumentController" customModule="CocoaPods" customModuleProvider="target"/>
     </objects>
 </document>

--- a/app/CocoaPods/CPAppDelegate.h
+++ b/app/CocoaPods/CPAppDelegate.h
@@ -1,5 +1,7 @@
 #import <Cocoa/Cocoa.h>
 
+@class CPDocumentController;
 @interface CPAppDelegate : NSObject <NSApplicationDelegate>
+@property (nonatomic, strong) IBOutlet CPDocumentController *documentController; // This allows it to be initialized in time to replace `[NSDocumentController sharedController]`'s default instance
 @property (readonly) NSXPCConnection *reflectionService;
 @end

--- a/app/CocoaPods/CPDocumentController.swift
+++ b/app/CocoaPods/CPDocumentController.swift
@@ -1,0 +1,29 @@
+import Cocoa
+
+@objc class CPDocumentController: NSDocumentController {
+  static let DocumentOpenedNotification = "CPDocumentControllerDocumentOpenedNotification"
+  static let RecentDocumentUpdateNotification = "CPDocumentControllerRecentDocumentUpdateNotification"
+  static let ClearRecentDocumentsNotification = "CPDocumentControllerClearRecentDocumentsNotification"
+  
+  // All of the `openDocument...` calls end up calling this one method, so adding our notification here is simple
+  
+  override func openDocumentWithContentsOfURL(url: NSURL, display displayDocument: Bool, completionHandler: (NSDocument?, Bool, NSError?) -> Void) {
+    super.openDocumentWithContentsOfURL(url, display: displayDocument, completionHandler: completionHandler)
+
+    NSNotificationCenter.defaultCenter().postNotificationName(CPDocumentController.DocumentOpenedNotification, object: self)
+  }
+  
+  // `noteNewRecentDocument` ends up calling to this method so we can just override this one method
+  
+  override func noteNewRecentDocumentURL(url: NSURL) {
+    super.noteNewRecentDocumentURL(url)
+    
+    NSNotificationCenter.defaultCenter().postNotificationName(CPDocumentController.RecentDocumentUpdateNotification, object: self)
+  }
+  
+  override func clearRecentDocuments(sender: AnyObject?) {
+    super.clearRecentDocuments(sender)
+    
+    NSNotificationCenter.defaultCenter().postNotificationName(CPDocumentController.ClearRecentDocumentsNotification, object: self)
+  }
+}

--- a/app/CocoaPods/CPDocumentController.swift
+++ b/app/CocoaPods/CPDocumentController.swift
@@ -1,6 +1,10 @@
 import Cocoa
 
-@objc class CPDocumentController: NSDocumentController {
+// This subclass is required so that the app can broadcast notifications when document 
+// based events occur, e.g. opening a document or updates to recently opened documents list.
+// The base `NSDocumentController` class currently has no built-in notifications for these events.
+
+class CPDocumentController: NSDocumentController {
   static let DocumentOpenedNotification = "CPDocumentControllerDocumentOpenedNotification"
   static let RecentDocumentUpdateNotification = "CPDocumentControllerRecentDocumentUpdateNotification"
   static let ClearRecentDocumentsNotification = "CPDocumentControllerClearRecentDocumentsNotification"
@@ -15,8 +19,6 @@ import Cocoa
       
       completionHandler(document, displayDocument, error)
     }
-
-    
   }
   
   // `noteNewRecentDocument` ends up calling to this method so we can just override this one method

--- a/app/CocoaPods/CPDocumentController.swift
+++ b/app/CocoaPods/CPDocumentController.swift
@@ -8,9 +8,15 @@ import Cocoa
   // All of the `openDocument...` calls end up calling this one method, so adding our notification here is simple
   
   override func openDocumentWithContentsOfURL(url: NSURL, display displayDocument: Bool, completionHandler: (NSDocument?, Bool, NSError?) -> Void) {
-    super.openDocumentWithContentsOfURL(url, display: displayDocument, completionHandler: completionHandler)
+    super.openDocumentWithContentsOfURL(url, display: displayDocument) { (document, displayDocument, error) -> Void in
+      if let _ = document { // Only fire the notification if we have a document
+        NSNotificationCenter.defaultCenter().postNotificationName(CPDocumentController.DocumentOpenedNotification, object: self)
+      }
+      
+      completionHandler(document, displayDocument, error)
+    }
 
-    NSNotificationCenter.defaultCenter().postNotificationName(CPDocumentController.DocumentOpenedNotification, object: self)
+    
   }
   
   // `noteNewRecentDocument` ends up calling to this method so we can just override this one method

--- a/app/CocoaPods/CPDocumentSource.swift
+++ b/app/CocoaPods/CPDocumentSource.swift
@@ -1,0 +1,14 @@
+
+import Cocoa
+
+// `CPDocumentSourceDelegate` needs to be marked `@objc` to allow it to be used as an IBOutlet
+
+@objc protocol CPDocumentSourceDelegate {
+  func documentSourceDidUpdate(documentSource: CPDocumentSource, documents: [CPHomeWindowDocumentEntry])
+}
+
+// A base class for the document sources of the `CPSidebarDocumentsController`
+class CPDocumentSource: NSObject {
+  @IBOutlet weak var delegate: CPDocumentSourceDelegate?
+  var documents : [CPHomeWindowDocumentEntry] { return [] }
+}

--- a/app/CocoaPods/CPHomeSidebarButton.swift
+++ b/app/CocoaPods/CPHomeSidebarButton.swift
@@ -5,9 +5,33 @@ import Cocoa
 
 class CPHomeSidebarButton: NSButton {
 
+  // Setting `enabled` to false, will color the text `disabledControlTextColor` which we use as the selected state color
+  // By adding `userInteractionEnabled` we can disable interaction while still having the color we want when deselected
+  // Using this boolean we override the mouse events and first responder as needed
+  var userInteractionEnabled: Bool = true
+  
   override func awakeFromNib() {
+    // This is the title for deselected, e.g. NSOffState
     self.attributedTitle =  NSAttributedString(title, color: NSColor(calibratedWhite: 0.8, alpha: 1), font: .labelFontOfSize(12), alignment: .Center)
+    
+    // This alternate title is the attributes used when selected, e.g. NSOnState
+    // `disabledControlTextColor` is used as this was the previous color for the selected state
+    self.attributedAlternateTitle = NSAttributedString(title, color: .disabledControlTextColor(), font: .labelFontOfSize(12), alignment: .Center)
+  }
+ 
+  override func mouseDown(theEvent: NSEvent) {
+    if userInteractionEnabled {
+      super.mouseDown(theEvent)
+    }
+  }
+  
+  override func mouseUp(theEvent: NSEvent) {
+    if userInteractionEnabled {
+      super.mouseUp(theEvent)
+    }
+  }
 
-    self.attributedAlternateTitle = NSAttributedString(title, color: .blueColor(), font: .labelFontOfSize(12), alignment: .Center)
+  override func becomeFirstResponder() -> Bool {
+    return userInteractionEnabled
   }
 }

--- a/app/CocoaPods/CPRecentDocumentSource.swift
+++ b/app/CocoaPods/CPRecentDocumentSource.swift
@@ -3,11 +3,30 @@ import Cocoa
 /// Not much going on, just provides recent documents
 /// note: is not memoized.
 
-class CPRecentDocumentSource: NSObject {
-
-  var recentDocuments: [CPHomeWindowDocumentEntry] {
-    let docs = NSDocumentController.sharedDocumentController()
-    return docs.recentDocumentURLs.map { CPHomeWindowDocumentEntry(URL: $0) }
+class CPRecentDocumentSource: CPDocumentSource {
+  
+  override var documents: [CPHomeWindowDocumentEntry] {
+    get {
+      let docs = NSDocumentController.sharedDocumentController()
+      return docs.recentDocumentURLs.map { CPHomeWindowDocumentEntry(URL: $0) }
+    }
   }
   
+  override init() {
+    super.init()
+    
+    let notificationCenter = NSNotificationCenter.defaultCenter()
+    notificationCenter.addObserver(self, selector: "updateRecentDocuments:", name: CPDocumentController.ClearRecentDocumentsNotification, object: nil)
+    notificationCenter.addObserver(self, selector: "updateRecentDocuments:", name: CPDocumentController.RecentDocumentUpdateNotification, object: nil)
+  }
+  
+  deinit {
+    let notificationCenter = NSNotificationCenter.defaultCenter()
+    notificationCenter.removeObserver(self, name: CPDocumentController.ClearRecentDocumentsNotification, object: nil)
+    notificationCenter.removeObserver(self, name: CPDocumentController.RecentDocumentUpdateNotification, object: nil)
+  }
+  
+  func updateRecentDocuments(notification: NSNotification) {
+    self.delegate?.documentSourceDidUpdate(self, documents: documents)
+  }
 }

--- a/app/CocoaPods/CPSidebarDocumentsController.swift
+++ b/app/CocoaPods/CPSidebarDocumentsController.swift
@@ -25,6 +25,10 @@ class CPSidebarDocumentsController: NSObject {
   // the `source.documents.isEmpty?` if statment
 
   override func awakeFromNib() {
+    updateCurrentSidebarDocuments()
+  }
+  
+  func updateCurrentSidebarDocuments() {
     if recentSource.recentDocuments.count > 0 {
       recentButtonTapped(recentButton)
     } else {
@@ -35,12 +39,16 @@ class CPSidebarDocumentsController: NSObject {
   @IBAction func recentButtonTapped(sender: NSButton) {
     currentSidebarItems = recentSource.recentDocuments
     selectButton(sender)
+    
+    observeRecentDocumentNotifications(true)
   }
 
   @IBAction func spotlightButtonTapped(sender: NSButton) {
     let source = spotlightSource
     currentSidebarItems = source.documents
     selectButton(sender)
+    
+    observeRecentDocumentNotifications(false)
 
     // Could either be no podfiles
     // on the users computer - or still searching
@@ -62,6 +70,23 @@ class CPSidebarDocumentsController: NSObject {
           self.spotlightButtonTapped(sender)
         }
       }
+    }
+  }
+  
+  func observeRecentDocumentNotifications(observe: Bool) {
+    let notificationCenter = NSNotificationCenter.defaultCenter()
+    
+    // We only want to observe these notifications if the "Recent" tab is open otherwise 
+    // we would switch back from the "Spotlight" tab `on data update
+    
+    if observe {
+      
+      // Calling `resetCurrentSideBarDocuments` ensures we will have something to show in the UI, not just blank space
+      notificationCenter.addObserver(self, selector: "updateCurrentSidebarDocuments", name: CPDocumentController.ClearRecentDocumentsNotification, object: nil)
+      notificationCenter.addObserver(self, selector: "updateCurrentSidebarDocuments", name: CPDocumentController.RecentDocumentUpdateNotification, object: nil)
+    } else {
+      notificationCenter.removeObserver(self, name: CPDocumentController.ClearRecentDocumentsNotification, object: nil)
+      notificationCenter.removeObserver(self, name: CPDocumentController.RecentDocumentUpdateNotification, object: nil)
     }
   }
 


### PR DESCRIPTION
Fixes #186 

Adds a custom NSDocumentController, `CPDocumentController` that allows us to add custom notifications when a file is opened or added to `recentDocumentURLs`

Oddly just opening a file does not add it to `recentDocumentURLs` but does add it to the "Open Recent..." menu immediately. When the window for the file is shut, it will then append to that array of files.