### PR TITLE
Don't crash when switching between libs/frameworks in a Podfile

### DIFF
--- a/app/CocoaPods/CPXcodeInformationGenerator.m
+++ b/app/CocoaPods/CPXcodeInformationGenerator.m
@@ -20,7 +20,7 @@
 - (NSArray<CPXcodeProject *> * _Nonnull)xcodeProjectsFromProject:(CPUserProject *)project
 {
   NSDictionary *xcodeprojs = project.xcodeIntegrationDictionary[@"projects"];
-  BOOL usesFrameworks = [project.xcodeIntegrationDictionary[@"uses_frameworks"] boolValue];
+  BOOL usesFrameworks = project.xcodeIntegrationDictionary[@"uses_frameworks"] != [NSNull null];
 
   // We promise non-null, so return empty array
   if (xcodeprojs.allKeys.count == 0) { return @[]; }


### PR DESCRIPTION
If I switch a Podfile between static libs / frameworks, the uses_frameworks comes through as an `NSNull` and crashes as it doesn't respond to `boolValue`.