### PR TITLE
Console background image should only be visible when the console does…

### DIFF
--- a/app/CocoaPods/CPPodfileConsoleTextView.swift
+++ b/app/CocoaPods/CPPodfileConsoleTextView.swift
@@ -2,13 +2,18 @@ import Cocoa
 
 class CPPodfileConsoleTextView: NSTextView {
   
+  dynamic var hasText: Bool = false //Currently bound to the hidden property of the console hint button
+  
   // We bind to `attributedText`, not `attributedString` in the storyboard, this is
   // to allow us to calculate the previous scroll position before setting the new
   // `attributedString` value which updates the text view
   var attributedText: NSAttributedString? {
     
     didSet {
-      guard let attributedText = attributedText else { return }
+      guard let attributedText = attributedText else {
+        hasText = false
+        return
+      }
       
       // Determine if we're at the tail of the output log (and should scroll) before we append more to it.
       
@@ -17,6 +22,7 @@ class CPPodfileConsoleTextView: NSTextView {
       // Setting via `textStorage` as we cannot call `setAttributedString` directly
       
       self.textStorage?.setAttributedString(attributedText)
+      self.hasText = attributedText.length != 0
       
       // Keep the text view at the bottom if it was previously, otherwise restore the previous position.
       

--- a/app/CocoaPods/Podfile.storyboard
+++ b/app/CocoaPods/Podfile.storyboard
@@ -847,6 +847,7 @@ Hit install to see the outcome</string>
                                 </buttonCell>
                                 <connections>
                                     <action selector="hintButton:" target="hxh-b1-faZ" id="ARj-pc-Ofs"/>
+                                    <binding destination="hxh-b1-faZ" name="hidden" keyPath="self.textView.hasText" id="dLo-pX-rV4"/>
                                 </connections>
                             </button>
                         </subviews>


### PR DESCRIPTION
… not contain any text

Fixes #224 

I added a hasText boolean to CPPodfileConsoleTextView that is bound to the hidden property of the hint button