### PR TITLE
Sparkler for metadata logging and graphs

### DIFF
--- a/app/CocoaPods/Supporting Files/Info.plist
+++ b/app/CocoaPods/Supporting Files/Info.plist
@@ -82,7 +82,9 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>SUEnableSystemProfiling</key>
+	<true/>
 	<key>SUFeedURL</key>
-	<string>https://app.cocoapods.org/sparkle.xml</string>
+	<string>https://usage.cocoapods.org/feeds/cocoapods_app.xml</string>
 </dict>
 </plist>


### PR DESCRIPTION
This hooks the app up to https://github.com/CocoaPods/sparkler. Sparkle passes on profile information from the app through sparkler which saves the metadata and then mirrors the sparkle .xml on the `gh-pages` branch.

This process is outlined [here](https://sparkle-project.org/documentation/system-profiling/).

Fixes #43.

Example of what this results in [here](http://sparkle.psionides.eu/feeds/gitifier/statistics).