### PR TITLE
Lockfile version checking

### DIFF
--- a/app/CPReflectionService/CPReflectionService.m
+++ b/app/CPReflectionService/CPReflectionService.m
@@ -21,6 +21,17 @@
   }];
 }
 
+- (void)versionFromLockfile:(NSString * _Nonnull)path
+                  withReply:(void (^ _Nonnull)(NSString * _Nullable, NSError * _Nullable))reply;
+{
+  [RBObject performBlock:^{
+    RBPathname *rubyPath = [RBObjectFromString(@"Pathname") new:path];
+    reply([RBObjectFromString(@"Pod::App") lockfile_version:rubyPath], nil);
+  } error:^(NSError * _Nonnull error) {
+    reply(nil, error);
+  }];
+}
+
 - (void)installedPlugins:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable plugins, NSError * _Nullable error))reply;
 {
   [RBObject performBlock:^{

--- a/app/CPReflectionService/CPReflectionService.m
+++ b/app/CPReflectionService/CPReflectionService.m
@@ -32,6 +32,17 @@
   }];
 }
 
+- (void)appVersion:(NSString * _Nonnull)appVersion isOlderThanLockfileVersion:(NSString * _Nonnull)lockfileVersion withReply:(void (^)(NSNumber * _Nullable, NSError * _Nullable))reply;
+{
+  [RBObject performBlock:^{
+    NSNumber *comparison = [RBObjectFromString(@"Pod::App") compare_versions:appVersion :lockfileVersion];
+    NSNumber *older = [comparison integerValue] < 0 ? @1 : @0;
+    reply(older, nil);
+  } error:^(NSError * _Nonnull error) {
+    reply(nil, error);
+  }];
+}
+
 - (void)installedPlugins:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable plugins, NSError * _Nullable error))reply;
 {
   [RBObject performBlock:^{

--- a/app/CPReflectionService/CPReflectionServiceProtocol.h
+++ b/app/CPReflectionService/CPReflectionServiceProtocol.h
@@ -12,6 +12,9 @@
 - (void)pluginsFromPodfile:(NSString * _Nonnull)contents
                  withReply:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable plugins, NSError * _Nullable error))reply;
 
+- (void)versionFromLockfile:(NSString * _Nonnull)path
+                  withReply:(void (^ _Nonnull)(NSString * _Nullable version, NSError * _Nullable error))reply;
+
 - (void)allPods:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable pods, NSError * _Nullable error))reply;
 
 @end

--- a/app/CPReflectionService/CPReflectionServiceProtocol.h
+++ b/app/CPReflectionService/CPReflectionServiceProtocol.h
@@ -15,6 +15,10 @@
 - (void)versionFromLockfile:(NSString * _Nonnull)path
                   withReply:(void (^ _Nonnull)(NSString * _Nullable version, NSError * _Nullable error))reply;
 
+- (void)appVersion:(NSString * _Nonnull)appVersion
+isOlderThanLockfileVersion:(NSString * _Nonnull)lockfileVersion
+         withReply:(void (^ _Nonnull)(NSNumber * _Nullable older, NSError * _Nullable error))reply;
+
 - (void)allPods:(void (^ _Nonnull)(NSArray<NSString *> * _Nullable pods, NSError * _Nullable error))reply;
 
 @end

--- a/app/CPReflectionService/RBObject+CocoaPods.h
+++ b/app/CPReflectionService/RBObject+CocoaPods.h
@@ -50,5 +50,6 @@ typedef void (^RBObjectErrorBlock)(NSError * _Nonnull error);
 - (NSDictionary * _Nonnull)analyze_podfile:(RBPodfile * _Nonnull)contents :(NSString * _Nonnull)installationRoot;
 - (NSArray<NSString *> * _Nullable)all_pods;
 - (NSString * _Nullable)lockfile_version:(RBPathname * _Nonnull)path;
+- (NSNumber * _Nonnull)compare_versions:(NSString * _Nonnull)version1 :(NSString * _Nonnull)version2;
 @end
 

--- a/app/CPReflectionService/RBObject+CocoaPods.h
+++ b/app/CPReflectionService/RBObject+CocoaPods.h
@@ -49,5 +49,6 @@ typedef void (^RBObjectErrorBlock)(NSError * _Nonnull error);
 - (void)require_gems;
 - (NSDictionary * _Nonnull)analyze_podfile:(RBPodfile * _Nonnull)contents :(NSString * _Nonnull)installationRoot;
 - (NSArray<NSString *> * _Nullable)all_pods;
+- (NSString * _Nullable)lockfile_version:(RBPathname * _Nonnull)path;
 @end
 

--- a/app/CPReflectionService/RBObject+CocoaPods.rb
+++ b/app/CPReflectionService/RBObject+CocoaPods.rb
@@ -64,5 +64,10 @@ module Pod
     def self.all_pods
       Pod::SourcesManager.aggregate.all_pods
     end
+
+    def self.lockfile_version(path)
+      lockfile = Lockfile.from_file(path)
+      lockfile.cocoapods_version.to_s
+    end
   end
 end

--- a/app/CPReflectionService/RBObject+CocoaPods.rb
+++ b/app/CPReflectionService/RBObject+CocoaPods.rb
@@ -69,5 +69,9 @@ module Pod
       lockfile = Lockfile.from_file(path)
       lockfile.cocoapods_version.to_s
     end
+
+    def self.compare_versions(version1, version2)
+      Pod::Version.new(version1) <=> Pod::Version.new(version2)
+    end
   end
 end

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -115,7 +115,9 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate, SMLAu
   }
 
   func checkForUpdatesButtonPressed() {
-
+    if let url = NSURL(string: "https://cocoapods.org/app") {
+      NSWorkspace.sharedWorkspace().openURL(url)
+    }
   }
 
   func completions() -> [AnyObject]! {

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -74,10 +74,10 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate, SMLAu
     if let lockfilePath = podfileViewController?.userProject.lockfilePath() {
       pullVersionFromLockfile(lockfilePath, completion: { version in
         self.checkForOlderAppVersionWithLockfileVersion(version, completion: { older in
-          if older?.boolValue == true {
-            if let version = version {
-              self.showWarningForLockfileVersion(version)
-            }
+          if let old = older where old.boolValue == true {
+            NSOperationQueue.mainQueue().addOperationWithBlock({ () -> Void in
+              self.showWarningForNewerLockfile()
+            })
           }
         })
       })
@@ -103,11 +103,18 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate, SMLAu
         appDelegate()?.reflectionService.remoteObjectProxy.appVersion(appVersion, isOlderThanLockfileVersion: lockfileVersion, withReply: { (result, error) in
           completion(result)
         })
+    } else {
+      completion(nil)
     }
-    completion(nil)
   }
 
-  func showWarningForLockfileVersion(version: String) {
+  func showWarningForNewerLockfile() {
+    let title = NSLocalizedString("PODFILE_WINDOW_NEWER_LOCKFILE_ERROR_BUTTON_TITTLE", comment: "")
+    let message = NSLocalizedString("PODFILE_WINDOW_NEWER_LOCKFILE_ERROR", comment: "")
+    podfileViewController?.showWarningLabelWithSender(message, actionTitle: title, target: self, action: "checkForUpdatesButtonPressed", animated: true)
+  }
+
+  func checkForUpdatesButtonPressed() {
 
   }
 

--- a/app/CocoaPods/CPPodfileViewController.swift
+++ b/app/CocoaPods/CPPodfileViewController.swift
@@ -104,28 +104,33 @@ class CPPodfileViewController: NSViewController, NSTabViewDelegate {
 
   @IBOutlet weak var warningDoneButton: NSButton!
   @IBOutlet weak var warningLabel: NSTextField!
+  @IBOutlet weak var warningView: BlueView!
   @IBOutlet weak var warningLabelHeight: NSLayoutConstraint!
 
-  func showWarningLabelWithSender(message: String, actionTitle:String, target: AnyObject?, action: Selector, animated:Bool) {
-    view.layoutSubtreeIfNeeded()
-
-    let label = animated ? warningLabelHeight.animator() : warningLabelHeight
-    label.constant = 50
+  func showWarningLabelWithSender(message: String, actionTitle: String, target: AnyObject?, action: Selector, animated: Bool) {
+    let constraint = warningLabelHeight
+    warningLabelHeight.active = false
 
     warningLabel.stringValue = message
     warningDoneButton.title = actionTitle
     warningDoneButton.target = target
     warningDoneButton.action = action
     warningDoneButton.enabled = true
+    view.layoutSubtreeIfNeeded()
+
+    let height = animated ? constraint.animator() : constraint
+    height.constant = warningView.fittingSize.height
+    warningLabelHeight = constraint
+    constraint.active = true
   }
 
   func hideWarningLabel(animated:Bool = true) {
     view.layoutSubtreeIfNeeded()
-    let label = animated ? warningLabelHeight.animator() : warningLabelHeight
-    label.constant = 0
+    let constraint = animated ? warningLabelHeight.animator() : warningLabelHeight
+    constraint.constant = 0
+    constraint.active = true
     warningDoneButton.enabled = false
   }
-
 }
 
 extension NSViewController {

--- a/app/CocoaPods/CPUserProject.h
+++ b/app/CocoaPods/CPUserProject.h
@@ -41,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Register for when podfilePlugins and the xcodeIntegrationDictionary are filled
 - (void)registerForFullMetadataCallback:(void (^)(void))completion;
 
-@end
-
 NS_ASSUME_NONNULL_END
+
+/// Path to the Lockfile. returns nil if the Lockfile hasn't been created yet.
+- (NSString * _Nullable)lockfilePath;
+
+@end

--- a/app/CocoaPods/CPUserProject.m
+++ b/app/CocoaPods/CPUserProject.m
@@ -65,6 +65,16 @@
   [self.completionPromise checkForFulfillment];
 }
 
+- (NSString * _Nullable)lockfilePath
+{
+  NSString *podfileURL = self.fileURL.relativePath;
+  NSString *lockfileURL = [podfileURL stringByAppendingString:@".lock"];
+  if ([[NSFileManager defaultManager] fileExistsAtPath:lockfileURL]) {
+    return lockfileURL;
+  }
+  return nil;
+}
+
 #pragma mark - NSFilePresenter
 
 - (void)presentedItemDidChange

--- a/app/CocoaPods/Podfile.storyboard
+++ b/app/CocoaPods/Podfile.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
     </dependencies>
@@ -148,17 +148,20 @@
                                 <rect key="frame" x="78" y="0.0" width="537" height="50"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yge-Ir-okX">
-                                        <rect key="frame" x="18" y="15" width="234" height="20"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Label with some text doing something" id="mW1-wj-yJA">
+                                        <rect key="frame" x="18" y="18" width="234" height="17"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="uSa-wE-LiX"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Label with some text doing something" id="mW1-wj-yJA">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nvs-Zv-XUf" customClass="CPBorderedButton">
-                                        <rect key="frame" x="427" y="14" width="90" height="21"/>
+                                        <rect key="frame" x="367" y="14" width="150" height="21"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="90" id="1od-UY-AYg"/>
+                                            <constraint firstAttribute="width" constant="150" id="1od-UY-AYg"/>
                                             <constraint firstAttribute="height" constant="21" id="Mqr-rp-Dnd"/>
                                         </constraints>
                                         <buttonCell key="cell" type="bevel" title="help" bezelStyle="rounded" image="TransparentButtonBG" imagePosition="overlaps" alignment="center" alternateImage="TransparentButtonBGFilled" imageScaling="axesIndependently" inset="2" id="elj-BT-5d3" customClass="CPBorderedButtonCell">
@@ -172,7 +175,8 @@
                                     <constraint firstItem="yge-Ir-okX" firstAttribute="top" secondItem="32a-ce-wrv" secondAttribute="top" constant="15" id="WGf-Gk-qMp"/>
                                     <constraint firstItem="Nvs-Zv-XUf" firstAttribute="centerY" secondItem="32a-ce-wrv" secondAttribute="centerY" id="YL1-71-Ou1"/>
                                     <constraint firstItem="yge-Ir-okX" firstAttribute="leading" secondItem="32a-ce-wrv" secondAttribute="leading" constant="20" id="i0J-1Y-Ard"/>
-                                    <constraint firstAttribute="bottom" secondItem="yge-Ir-okX" secondAttribute="bottom" constant="15" id="ode-em-dMe"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="yge-Ir-okX" secondAttribute="bottom" constant="15" id="ode-em-dMe"/>
+                                    <constraint firstItem="Nvs-Zv-XUf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="yge-Ir-okX" secondAttribute="trailing" constant="20" id="r7O-qn-pOB"/>
                                     <constraint firstAttribute="height" constant="50" id="wFn-vf-vRd"/>
                                 </constraints>
                             </customView>
@@ -225,7 +229,8 @@
                         <outlet property="tabViewDelegate" destination="TcC-X8-fEE" id="rpc-oY-Jgh"/>
                         <outlet property="warningDoneButton" destination="Nvs-Zv-XUf" id="eYF-Pl-mG9"/>
                         <outlet property="warningLabel" destination="yge-Ir-okX" id="5rG-4b-9Hy"/>
-                        <outlet property="warningLabelHeight" destination="wFn-vf-vRd" id="aMT-qV-1Cr"/>
+                        <outlet property="warningLabelHeight" destination="wFn-vf-vRd" id="KiI-IT-elG"/>
+                        <outlet property="warningView" destination="32a-ce-wrv" id="jOe-JT-01R"/>
                     </connections>
                 </viewController>
                 <customObject id="2Tp-Fl-jBw" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -368,7 +373,7 @@
                                     <nil key="backgroundColor"/>
                                 </clipView>
                                 <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="PHf-HC-OTM">
-                                    <rect key="frame" x="1" y="-15" width="0.0" height="16"/>
+                                    <rect key="frame" x="1" y="-14" width="0.0" height="15"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="KRR-5W-Zmf">
@@ -432,14 +437,14 @@ Gw
                             <userLayoutGuide location="300" affinity="minX"/>
                         </userGuides>
                         <subviews>
-                            <scrollView misplaced="YES" autohidesScrollers="YES" horizontalLineScroll="150" horizontalPageScroll="10" verticalLineScroll="150" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AZX-Bo-Gby">
-                                <rect key="frame" x="0.0" y="-2" width="512" height="602"/>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="150" horizontalPageScroll="10" verticalLineScroll="150" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AZX-Bo-Gby">
+                                <rect key="frame" x="0.0" y="0.0" width="512" height="600"/>
                                 <clipView key="contentView" id="FRT-dS-9SW">
-                                    <rect key="frame" x="1" y="1" width="510" height="600"/>
+                                    <rect key="frame" x="1" y="1" width="510" height="598"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="150" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="Lnh-3i-Tcu">
-                                            <rect key="frame" x="0.0" y="0.0" width="510" height="600"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="510" height="598"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
@@ -817,10 +822,10 @@ Gw
                                             <rect key="frame" x="0.0" y="0.0" width="512" height="600"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <size key="minSize" width="512" height="600"/>
+                                            <size key="minSize" width="497" height="600"/>
                                             <size key="maxSize" width="600" height="10000000"/>
                                             <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="512" height="600"/>
+                                            <size key="minSize" width="497" height="600"/>
                                             <size key="maxSize" width="600" height="10000000"/>
                                             <connections>
                                                 <binding destination="hxh-b1-faZ" name="editable" keyPath="self.editable" id="rqN-Lz-pM6"/>
@@ -836,7 +841,7 @@ Gw
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="gUJ-tJ-SOq">
-                                    <rect key="frame" x="496" y="0.0" width="16" height="600"/>
+                                    <rect key="frame" x="497" y="0.0" width="15" height="600"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>

--- a/app/CocoaPods/Supporting Files/Localizable.strings
+++ b/app/CocoaPods/Supporting Files/Localizable.strings
@@ -24,6 +24,8 @@
 "PODFILE_WINDOW_CONSOLE_HINT_EMPTY_PODFILE" = "Your Podfile seems empty...\nClick here for some inspiration";
 "PODFILE_WINDOW_CONSOLE_HINT_ERROR_PODFILE" = "Your Podfile is having some problems";
 "PODFILE_WINDOW_CONSOLE_HINT_READY_PODFILE" = "Your Podfile is ready to go!\nHit install to see the outcome";
+"PODFILE_WINDOW_NEWER_LOCKFILE_ERROR" = "Your Podfile.lock was generated using a newer version of CocoaPods";
+"PODFILE_WINDOW_NEWER_LOCKFILE_ERROR_BUTTON_TITTLE" = "Check For Updates";
 
 "MAIN_WINDOW_TITLE" = "Welcome to CocoaPods";
 "MAIN_WINDOW_OPEN_GUIDES_BUTTON_TITLE" = "Get started with CocoaPods";


### PR DESCRIPTION
Closes #249.

- [x] Use RubyCocoa to get the CocoaPods version used to generate the `Lockfile`
- [x] Model and compare the app's version to the version of CocoaPods used to generate the `Lockfile`
- [x] Hook up the version check to the UI

A good way to test this is to edit a `Podfile.lock`'s CocoaPods version to something (say `1.1`) and open the Podfile in the app. It takes a bit of time to get info back from the bridge.