### PR TITLE
Add support for handling multiple Xcodeprojects in the same folder with pod init

### DIFF
--- a/app/CocoaPods/CPPodfileInitController.swift
+++ b/app/CocoaPods/CPPodfileInitController.swift
@@ -23,8 +23,9 @@ public class CPPodfileInitController: NSObject, CPCLITaskDelegate {
     self.projectURL = xcodeprojURL
     
     super.init()
+
     let task = CPCLITask(workingDirectory: xcodeprojURL.URLByDeletingLastPathComponent!.path,
-      command: "init",
+      command: "init \(xcodeprojURL.lastPathComponent!)",
       delegate: self,
       qualityOfService: .UserInitiated)
     self.task = task


### PR DESCRIPTION
Wanted to get back into the flow, so started testing the app a bit:

![screen shot 2016-04-05 at 20 35 08](https://cloud.githubusercontent.com/assets/49038/14295567/1beb3b62-fb6e-11e5-9631-5b8ec5b2fe08.png)

Now generates:

![screen shot 2016-04-05 at 20 35 01](https://cloud.githubusercontent.com/assets/49038/14295569/1d7ca240-fb6e-11e5-9035-2fc289052825.png)
