### PR TITLE
Add support for 'auto-update specs repo'

### DIFF
--- a/app/CocoaPods/Base.lproj/CPHomeWindowController.xib
+++ b/app/CocoaPods/Base.lproj/CPHomeWindowController.xib
@@ -23,7 +23,7 @@
         <window title="Welcome to CocoaPods" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="F0z-JX-Cv5" customClass="CPThickDecorationsWindow" customModule="CocoaPods" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" texturedBackground="YES" unifiedTitleAndToolbar="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="721" height="369"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="800"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1440"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="721" height="369"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -463,6 +463,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="Lmb-6g-oqt"/>
+                            <menuItem title="Auto-Update Specs Repos" id="bei-ab-BDq">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleUpdateSpecsRepo:" target="-1" id="NBL-g1-bOd"/>
+                                </connections>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>

--- a/app/CocoaPods/CPInstallAction.swift
+++ b/app/CocoaPods/CPInstallAction.swift
@@ -1,8 +1,20 @@
 import Cocoa
 
 enum InstallActionType {
-  case Install(verbose: Bool)
-  case Update(verbose: Bool)
+  case Install(options: InstallOptions)
+  case Update(options: InstallOptions)
+}
+
+struct InstallOptions {
+  let verbose: Bool
+  let repoUpdate: Bool
+
+  var commandOptions : String {
+    var string = ""
+    if verbose { string += "--verbose " }
+    if repoUpdate { string += "--repo-update " }
+    return string
+  }
 }
 
 class CPInstallAction: NSObject, CPCLITaskDelegate {
@@ -18,10 +30,10 @@ class CPInstallAction: NSObject, CPCLITaskDelegate {
 
   func performAction(type: InstallActionType) {
     switch type {
-    case .Install(let verbose):
-      executeTaskWithCommand(verbose ? "install --verbose" : "install")
-    case .Update(let verbose):
-      executeTaskWithCommand(verbose ? "update --verbose" : "update")
+    case .Install(let options):
+      executeTaskWithCommand("install \(options.commandOptions)")
+    case .Update(let options):
+      executeTaskWithCommand("update \(options.commandOptions)")
     }
   }
 

--- a/app/CocoaPods/CPMenuVisiblityDirector.swift
+++ b/app/CocoaPods/CPMenuVisiblityDirector.swift
@@ -21,14 +21,14 @@ class CPMenuVisiblityDirector: NSObject {
     notificationCenter.addObserver(self, selector: #selector(windowsChanged(_:)), name: NSWindowDidBecomeKeyNotification, object: nil)
   }
 
-  /// Set hidden on the menus when we don't need to show the submenus
+  /// Set hidden on the menus when we don't need to enable the submenus
   func windowsChanged(notification: NSNotification) {
     guard let window = notification.object as? NSWindow else { return print("Notification does not have a window") }
     let docs = NSDocumentController.sharedDocumentController()
     let windowHasDocument = docs.documentForWindow(window) != nil
 
     for menu in podfileEditorMenuItems {
-      menu.enabled = !windowHasDocument
+      menu.enabled = windowHasDocument
     }
   }
 }

--- a/app/CocoaPods/CPPodfileViewController.swift
+++ b/app/CocoaPods/CPPodfileViewController.swift
@@ -65,25 +65,29 @@ class CPPodfileViewController: NSViewController, NSTabViewDelegate {
 
   @IBAction func install(obj: AnyObject) {
     userProject.saveDocument(self)
-    installAction.performAction(.Install(verbose: false))
+    let options = InstallOptions(verbose: false, repoUpdate: shouldUpdateSpecsRepo())
+    installAction.performAction(.Install(options: options))
     showConsoleTab(self)
   }
 
   @IBAction func installVerbose(obj: AnyObject) {
     userProject.saveDocument(self)
-    installAction.performAction(.Install(verbose: true))
+    let options = InstallOptions(verbose: true, repoUpdate: shouldUpdateSpecsRepo())
+    installAction.performAction(.Install(options: options))
     showConsoleTab(self)
   }
 
   @IBAction func installUpdate(obj: AnyObject) {
     userProject.saveDocument(self)
-    installAction.performAction(.Update(verbose: false))
+    let options = InstallOptions(verbose: false, repoUpdate: shouldUpdateSpecsRepo())
+    installAction.performAction(.Update(options: options))
     showConsoleTab(self)
   }
 
   @IBAction func installUpdateVerbose(obj: AnyObject) {
     userProject.saveDocument(self)
-    installAction.performAction(.Update(verbose: true))
+    let options = InstallOptions(verbose: true, repoUpdate: shouldUpdateSpecsRepo())
+    installAction.performAction(.Update(options: options))
     showConsoleTab(self)
   }
 
@@ -93,6 +97,25 @@ class CPPodfileViewController: NSViewController, NSTabViewDelegate {
     NSMenu.popUpContextMenu(installMenu, withEvent: event, forView: button)
   }
 
+  let UpdateSpecsKey = "CPUpdateSpecsRepos"
+  func shouldUpdateSpecsRepo() -> Bool {
+    return NSUserDefaults.standardUserDefaults().boolForKey(UpdateSpecsKey)
+  }
+
+  @IBAction func toggleUpdateSpecsRepo(obj: AnyObject)  {
+    let defaults = NSUserDefaults.standardUserDefaults()
+    let current = defaults.boolForKey(UpdateSpecsKey)
+    defaults.setBool(!current, forKey: UpdateSpecsKey)
+    defaults.synchronize()
+  }
+
+  override func validateMenuItem(menuItem: NSMenuItem) -> Bool {
+    if menuItem.action == #selector(toggleUpdateSpecsRepo) {
+      let state = shouldUpdateSpecsRepo() ? 1 : 0
+      menuItem.state = state
+    }
+    return true
+  }
 
   @IBAction func showEditorTab(sender: AnyObject) {
     tabController.selectedTabViewItemIndex = 0

--- a/app/CocoaPods/Podfile.storyboard
+++ b/app/CocoaPods/Podfile.storyboard
@@ -255,6 +255,13 @@
                                 <action selector="installUpdateVerbose:" target="5gI-5U-AMq" id="dCA-77-Jc3"/>
                             </connections>
                         </menuItem>
+                        <menuItem isSeparatorItem="YES" id="MfJ-p0-dcA"/>
+                        <menuItem title="Auto-Update Specs Repos" id="7VJ-3T-Bex">
+                            <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="toggleUpdateSpecsRepo:" target="5gI-5U-AMq" id="shm-m1-s3m"/>
+                            </connections>
+                        </menuItem>
                     </items>
                 </menu>
                 <userDefaultsController representsSharedInstance="YES" id="LcC-8e-1XM"/>


### PR DESCRIPTION
When I started thinking about what the Specs Repo update stuff should look like. I missed the simplest option, and instead went for a more complex but more design-y answer in https://github.com/CocoaPods/CocoaPods-app/issues/260 - thanks for the comments @segiddins 

I think there's probably still a space for something like #260 - but it's vastly reduced it's need now.

<img width="935" alt="screen shot 2016-04-19 at 00 16 15" src="https://cloud.githubusercontent.com/assets/49038/14622724/fc1cb97c-05c3-11e6-9899-50247c81011f.png">

and

<img width="635" alt="screen shot 2016-04-19 at 00 16 38" src="https://cloud.githubusercontent.com/assets/49038/14622730/0bcaa8a2-05c4-11e6-9107-347888b8d4a4.png">
