### PR TITLE
Remove the auto repo update button on the main menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## master
+## Master
+
+* Removes an unused menu item for specs repo updating  
+  [orta](https://github.com/orta)
+  [#314](https://github.com/CocoaPods/CocoaPods-app/pull/314)
+
+## [1.0.0.rc.1](https://github.com/CocoaPods/CocoaPods-app/releases/tag/1.0.0.rc.1)
 
 * Fixes to Sparkle updates, by returning to CocoaPods' version numbers  
   [orta](https://github.com/orta)  

--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -473,13 +473,6 @@
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="installUpdateVerbose:" target="-1" id="zdL-aU-D8R"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="Lmb-6g-oqt"/>
-                            <menuItem title="Auto-Update Specs Repos" id="bei-ab-BDq">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="toggleUpdateSpecsRepo:" target="-1" id="NBL-g1-bOd"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
We had a menu item that wasn't hooked up to anything after I re-implmented the Specs repo updating sections.