### PR TITLE
[Editor] Disable autocomplete in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Master
 
+* Disable autocomplete in comments  
+	[k0nserv](https://github.com/k0nserv)
+	[#329](https://github.com/CocoaPods/CocoaPods-app/pull/329)
+
+## [1.0.0](https://github.com/CocoaPods/CocoaPods-app/releases/tag/1.0.0)
+
 * Removes an unused menu item for specs repo updating  
   [orta](https://github.com/orta)
   [#314](https://github.com/CocoaPods/CocoaPods-app/pull/314)

--- a/app/CocoaPods/CPPodfileEditorViewController.swift
+++ b/app/CocoaPods/CPPodfileEditorViewController.swift
@@ -144,7 +144,18 @@ class CPPodfileEditorViewController: NSViewController, NSTextViewDelegate, SMLAu
            stringBefore.componentsSeparatedByString("\"").count == 2
   }
 
+  var cursorInComment: Bool {
+    guard let line = selectedLines(editor.textView).first else { return false }
+    let trimmed = line.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+
+    return (trimmed as NSString).substringToIndex(1) == "#"
+  }
+
   func completions() -> [AnyObject]! {
+    if cursorInComment {
+      return []
+    }
+
     return cursorIsInsidePodQuote ? allPodNames : autoCompletions
   }
 


### PR DESCRIPTION
Prevent autocomplete in comments by detecting them an returning `[]` as the completions

Fixes: #328