### PR TITLE
[Podfile Editor] Allow option clicking on a pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Allow option clicking on a pod
   [pedrovieira7](https://github.com/pedrovieira7)
-  [#302](https://github.com/CocoaPods/CocoaPods-app/issues/302)
+  [#333](https://github.com/CocoaPods/CocoaPods-app/pull/333)
 
 * Remember the editor window size across runs  
   [K0nserv](https://github.com/k0nserv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+* Allow option clicking on a pod
+  [pedrovieira7](https://github.com/pedrovieira7)
+  [#302](https://github.com/CocoaPods/CocoaPods-app/issues/302)
+
 * Remember the editor window size across runs  
   [K0nserv](https://github.com/k0nserv)
   [#330](https://github.com/CocoaPods/CocoaPods-app/pull/330)
@@ -77,18 +81,18 @@
 * Migrate project to Xcode 7.3
   [Nate West](https://github.com/nwest)
   [#274](https://github.com/CocoaPods/CocoaPods-app/pull/274)
-  
-## [1.0.0.beta.5 2016.03.03](https://github.com/CocoaPods/CocoaPods-app/releases/tag/1.0.0.beta.5) 
+
+## [1.0.0.beta.5 2016.03.03](https://github.com/CocoaPods/CocoaPods-app/releases/tag/1.0.0.beta.5)
    [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#100beta5-2016-03-08)
 
 * Prompt to move to /Applications  
   [Daniel Tomlinson](https://github.com/DanielTomlinson)
   [#244](https://github.com/CocoaPods/CocoaPods-app/pull/244)
-  
+
 * Ability to open the folder / Xcode project from the Podfile Metadata View  
   [Wojciech Rutkowski](https://github.com/wrutkowski)
   [#246](https://github.com/CocoaPods/CocoaPods-app/pull/246)
-  
+
 * Support for `pod init`  
   [Daniel Tomlinson](https://github.com/DanielTomlinson)
   [#245](https://github.com/CocoaPods/CocoaPods-app/pull/245)
@@ -99,39 +103,39 @@
 * Target and project information  
   [Eloy Durán](https://github.com/alloy)
   [#161](https://github.com/CocoaPods/CocoaPods-app/pull/161)
-  
+
 * Font increase and decrease options in Podfile editor  
   [Wojciech Rutkowski](https://github.com/wrutkowski)
   [#177](https://github.com/CocoaPods/CocoaPods-app/pull/177)
-  
+
 * Open button on Home Window for empty Recent list  
   [Wojciech Rutkowski](https://github.com/wrutkowski)
   [#185](https://github.com/CocoaPods/CocoaPods-app/pull/185)
-  
+
 * Show Project Info  
   [Orta Therox](https://github.com/orta)
   [#141](https://github.com/CocoaPods/CocoaPods-app/pull/141)
-  
+
 * Detect and recommend Plugins required by a Podfile  
   [Orta Therox](https://github.com/orta)
   [#131](https://github.com/CocoaPods/CocoaPods-app/pull/131)
-  
+
 * Pod name autocomplete while editing Podfile  
   [Nate West](https://github.com/nwest)
   [#197](https://github.com/CocoaPods/CocoaPods-app/pull/197)
-  
+
 * Drag & Drop functionality on Home Window  
   [Wojciech Rutkowski](https://github.com/wrutkowski)
   [#184](https://github.com/CocoaPods/CocoaPods-app/pull/184)
-  
+
 * Close button in Home Window closes the window  
   [Wojciech Rutkowski](https://github.com/wrutkowski)
   [#201](https://github.com/CocoaPods/CocoaPods-app/pull/201)
-  
+
 * Use spotlight as an additional way of finding Podfiles  
   [Orta Therox](https://github.com/orta)
   [#198](https://github.com/CocoaPods/CocoaPods-app/pull/198)
-  
+
 * Support highlighting CP DSL errors when they are not ruby syntax issues  
   [Orta Therox](https://github.com/orta)
   [#205](https://github.com/CocoaPods/CocoaPods-app/pull/205)
@@ -139,31 +143,31 @@
 * Add CPPodfileConsoleTextView to allow auto scrolling  
   [Aaron Pearce](https://github.com/aaronpearce)
   [#213](https://github.com/CocoaPods/CocoaPods-app/pull/213)
-  
+
 * Empty console hints  
   [Wojciech Rutkowski](https://github.com/wrutkowski)
   [#212](https://github.com/CocoaPods/CocoaPods-app/pull/212)
-  
+
 * Add support for tracking if the Podfile has been edited in another app  
   [Naiko](https://github.com/Naiko)
   [#220](https://github.com/CocoaPods/CocoaPods-app/pull/220)
-  
+
 * Add Notifications for recent and newly opened files  
   [Aaron Pearce](https://github.com/aaronpearce)
   [#222](https://github.com/CocoaPods/CocoaPods-app/pull/222)
-  
+
 ## [1.0.0.beta.2 2016.01.12](https://github.com/CocoaPods/CocoaPods-app/releases/tag/1.0.0.beta.2)
   [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#100beta2-2016-01-05)
 
 ## [0.39.0 2015.10.11](https://github.com/CocoaPods/CocoaPods-app/releases/tag/0.39.0)
   [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#0390-2015-10-09)
-  
+
 ## [0.38.2 2015.07.26](https://github.com/CocoaPods/CocoaPods-app/releases/tag/0.38.2)
   [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#0382-2015-07-25)
-  
+
 ## [0.38.0 2015.07.22](https://github.com/CocoaPods/CocoaPods-app/releases/tag/0.38.0)
   [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#0380-2015-07-18)
-  
+
 ## [0.37.0 2015.05.03](https://github.com/CocoaPods/CocoaPods-app/releases/tag/0.37.0)
   [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#0370-2015-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master
 
-* Allow option clicking on a pod
+* Allow option clicking on a pod  
   [pedrovieira7](https://github.com/pedrovieira7)
   [#333](https://github.com/CocoaPods/CocoaPods-app/pull/333)
 

--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -97,6 +97,10 @@
 		934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */; };
 		934FF1891C4F1E2A000B4302 /* CPDocumentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */; };
 		93FB07E11C503572007B2CDA /* CPDocumentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FB07E01C503572007B2CDA /* CPDocumentSource.swift */; };
+		C90778391CE68CB400A7E235 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C90778381CE68CB400A7E235 /* WebKit.framework */; };
+		C907783D1CE68CCE00A7E235 /* SMLTextView+OptionClickPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = C907783B1CE68CCE00A7E235 /* SMLTextView+OptionClickPopover.swift */; };
+		C907783E1CE68CCE00A7E235 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C907783C1CE68CCE00A7E235 /* String+Extensions.swift */; };
+		C90778401CE68CD900A7E235 /* CocoaPods.css in Resources */ = {isa = PBXBuildFile; fileRef = C907783F1CE68CD900A7E235 /* CocoaPods.css */; };
 		E70998471C49AB5B00229507 /* Podfile.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70998461C49AB5B00229507 /* Podfile.plist */; };
 		E72E9FDA1C6E328C00A8705B /* CPStringArrayToSentenceValueTransformerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72E9FD91C6E328C00A8705B /* CPStringArrayToSentenceValueTransformerSpec.swift */; };
 		E72E9FDC1C6E38B400A8705B /* CocoaPodsTests-Bridging-Header.h in Sources */ = {isa = PBXBuildFile; fileRef = E72E9FDB1C6E379200A8705B /* CocoaPodsTests-Bridging-Header.h */; };
@@ -296,6 +300,10 @@
 		934FF1861C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPPodfileConsoleTextView.swift; sourceTree = "<group>"; };
 		934FF1881C4F1E2A000B4302 /* CPDocumentController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPDocumentController.swift; sourceTree = "<group>"; };
 		93FB07E01C503572007B2CDA /* CPDocumentSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPDocumentSource.swift; sourceTree = "<group>"; };
+		C90778381CE68CB400A7E235 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		C907783B1CE68CCE00A7E235 /* SMLTextView+OptionClickPopover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SMLTextView+OptionClickPopover.swift"; sourceTree = "<group>"; };
+		C907783C1CE68CCE00A7E235 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		C907783F1CE68CD900A7E235 /* CocoaPods.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = CocoaPods.css; sourceTree = "<group>"; };
 		E70998461C49AB5B00229507 /* Podfile.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Podfile.plist; path = "Syntax Definitions/Podfile.plist"; sourceTree = "<group>"; };
 		E72E9FD91C6E328C00A8705B /* CPStringArrayToSentenceValueTransformerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPStringArrayToSentenceValueTransformerSpec.swift; sourceTree = "<group>"; };
 		E72E9FDB1C6E379200A8705B /* CocoaPodsTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CocoaPodsTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -321,6 +329,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C90778391CE68CB400A7E235 /* WebKit.framework in Frameworks */,
 				51CFC7861A2DF8E000F9ABCB /* Cocoa.framework in Frameworks */,
 				51CFC7841A2DF88700F9ABCB /* Security.framework in Frameworks */,
 				51165E531A1973CC00DCFC94 /* SecurityFoundation.framework in Frameworks */,
@@ -360,6 +369,7 @@
 		46126B404240E403B2193EE7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C90778381CE68CB400A7E235 /* WebKit.framework */,
 				514280C91C36C1BD00DCE23D /* libffi.tbd */,
 				51EA178F1C0155E9000DC69A /* RubyCocoa.framework */,
 				51CFC7851A2DF8E000F9ABCB /* Cocoa.framework */,
@@ -430,6 +440,7 @@
 				60FE01621B9B76400027EEE3 /* Home Window */,
 				FA16FACB1C14475200DC3791 /* URL Handling */,
 				60FE016D1B9B7F000027EEE3 /* Categories */,
+				C907783A1CE68CBD00A7E235 /* Extensions */,
 				51165E221A17AFF500DCFC94 /* Supporting Files */,
 			);
 			path = CocoaPods;
@@ -438,6 +449,7 @@
 		51165E221A17AFF500DCFC94 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				C907783F1CE68CD900A7E235 /* CocoaPods.css */,
 				5180FE931AD2A51300314D61 /* LICENSE */,
 				E70998461C49AB5B00229507 /* Podfile.plist */,
 				77356D741A2253F1002822CF /* Media.xcassets */,
@@ -683,6 +695,15 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		C907783A1CE68CBD00A7E235 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				C907783C1CE68CCE00A7E235 /* String+Extensions.swift */,
+				C907783B1CE68CCE00A7E235 /* SMLTextView+OptionClickPopover.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
 		FA16FACB1C14475200DC3791 /* URL Handling */ = {
 			isa = PBXGroup;
 			children = (
@@ -844,6 +865,7 @@
 				51D2E5B21A212A0800C0B153 /* SyntaxDefinitions.plist in Resources */,
 				51165E2D1A17AFF500DCFC94 /* MainMenu.xib in Resources */,
 				51D2E5B11A212A0800C0B153 /* Syntax Definitions in Resources */,
+				C90778401CE68CD900A7E235 /* CocoaPods.css in Resources */,
 				606D1ED21BF90705000B7148 /* Podfile.storyboard in Resources */,
 				E70998471C49AB5B00229507 /* Podfile.plist in Resources */,
 				6075BA651C068B5F00A5C491 /* Podfile.xcassets in Resources */,
@@ -1026,10 +1048,12 @@
 				51165E281A17AFF500DCFC94 /* main.m in Sources */,
 				601ACAA31C389E9B0058FA86 /* CPXcodeInformationGenerator.m in Sources */,
 				5EF5B7871C17990400F8C39E /* CPSideButton.swift in Sources */,
+				C907783D1CE68CCE00A7E235 /* SMLTextView+OptionClickPopover.swift in Sources */,
 				93FB07E11C503572007B2CDA /* CPDocumentSource.swift in Sources */,
 				1F9177581BA27592006698C9 /* CPHomeWindowController.m in Sources */,
 				60E693A91C49B5980058DF5F /* CPSpotlightDocumentSource.swift in Sources */,
 				934FF1871C4CB4ED000B4302 /* CPPodfileConsoleTextView.swift in Sources */,
+				C907783E1CE68CCE00A7E235 /* String+Extensions.swift in Sources */,
 				6075BA671C06963700A5C491 /* CPInstallAction.swift in Sources */,
 				60E693B91C4A8DAD0058DF5F /* CPRecentDocumentSource.swift in Sources */,
 				3311885A1BEBCB4200272793 /* CPCLITask.m in Sources */,

--- a/app/CocoaPods/CPFontAndColourGateKeeper.swift
+++ b/app/CocoaPods/CPFontAndColourGateKeeper.swift
@@ -23,6 +23,7 @@ class CPFontAndColourGateKeeper: NSObject {
   let cpBrightWhite = NSColor(calibratedRed:0.773, green:0.773, blue:0.773, alpha:1.00)
   let cpBrightLightBrown = NSColor(calibratedRed: 232/255, green:226/255 , blue: 224/255, alpha: 1)
   let cpBrightBrown = NSColor(calibratedRed: 209/255, green:196/255 , blue: 192/255, alpha: 1)
+  let cpLinkRed = NSColor(calibratedRed:0.91, green:0.22, blue:0.24, alpha:1.00)
   
   //MARK: - Font
   

--- a/app/CocoaPods/SMLTextView+OptionClickPopover.swift
+++ b/app/CocoaPods/SMLTextView+OptionClickPopover.swift
@@ -1,0 +1,266 @@
+import Fragaria
+import WebKit
+
+extension SMLTextView {
+  
+  private struct AssociatedKeys {
+    static var optionClickPopover = "org.cocoapods.CocoaPods.optionClickPopover"
+    static var selectedPodRange = "org.cocoapods.CocoaPods.selectedPodRange"
+    static var hoveredPodRange = "org.cocoapods.CocoaPods.hoveredPodRange"
+    static var optionKeyDown = "org.cocoapods.CocoaPods.optionKeyDown"
+  }
+  
+  var optionClickPopover: NSPopover? {
+    get {
+      return objc_getAssociatedObject(self, &AssociatedKeys.optionClickPopover) as? NSPopover
+    }
+    set {
+      objc_setAssociatedObject(self, &AssociatedKeys.optionClickPopover, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+  }
+  
+  // The pod name range where the NSPopover currently is
+  var selectedPodRange: NSRange? {
+    get {
+      return objc_getAssociatedObject(self, &AssociatedKeys.selectedPodRange) as? NSRange
+    }
+    set {
+      objc_setAssociatedObject(self, &AssociatedKeys.selectedPodRange, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+  }
+  
+  // The pod name range currently hovered with option key down (excluding when that range is the same
+  // as the one where the popover is)
+  var hoveredPodRange: NSRange? {
+    get {
+      return objc_getAssociatedObject(self, &AssociatedKeys.hoveredPodRange) as? NSRange
+    }
+    set {
+      objc_setAssociatedObject(self, &AssociatedKeys.hoveredPodRange, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+  }
+  
+  var isOptionKeyDown: Bool {
+    get {
+      return (objc_getAssociatedObject(self, &AssociatedKeys.optionKeyDown) as? Bool) ?? false
+    }
+    set {
+      objc_setAssociatedObject(self, &AssociatedKeys.optionKeyDown, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+  }
+  
+  
+  public override func mouseMoved(theEvent: NSEvent) {
+    super.mouseMoved(theEvent)
+    
+    guard theEvent.modifierFlags.contains(.AlternateKeyMask) else {
+      return
+    }
+    processPodMouseHover()
+  }
+  
+  public override func mouseDown(theEvent: NSEvent) {
+    super.mouseDown(theEvent)
+    
+    guard theEvent.modifierFlags.contains(.AlternateKeyMask) else {
+      return
+    }
+    quickLookWithEvent(theEvent)
+  }
+  
+  public override func quickLookWithEvent(event: NSEvent) {
+    guard let pod = checkForPodNameBelowMouseLocation() else {
+      optionClickPopover?.close()
+      return
+    }
+    
+    hoveredPodRange = nil
+    
+    showPodPopover(forPodWithName: pod.podName, atRange: pod.location)
+    updateUnderlineStyle(forPodAtRange: pod.location)
+    selectedPodRange = pod.location
+  }
+  
+  public override func flagsChanged(theEvent: NSEvent) {
+    if theEvent.modifierFlags.contains(.AlternateKeyMask) {
+      processPodMouseHover()
+      isOptionKeyDown = true
+      
+    } else if isOptionKeyDown {
+      removeUnderlineStyle(forPodAtRange: hoveredPodRange)
+      hoveredPodRange = nil
+      isOptionKeyDown = false
+    }
+    
+    super.flagsChanged(theEvent)
+  }
+  
+  private func processPodMouseHover() {
+    removeUnderlineStyle(forPodAtRange: hoveredPodRange)
+    hoveredPodRange = nil
+    
+    guard let pod = checkForPodNameBelowMouseLocation() else {
+      return
+    }
+    
+    updateUnderlineStyle(forPodAtRange: pod.location)
+    if selectedPodRange == nil || selectedPodRange!.location != pod.location.location {
+      hoveredPodRange = pod.location
+    }
+  }
+  
+  private func checkForPodNameBelowMouseLocation() -> (podName: String, location: NSRange)? {
+    guard let string = string else {
+      return nil
+    }
+    
+    let hoveredCharIndex = characterIndexForPoint(NSEvent.mouseLocation())
+    let lineRange = (string as NSString).lineRangeForRange(NSRange(location: hoveredCharIndex, length: 0))
+    let line = (string as NSString).substringWithRange(lineRange)
+    let hoveredCharLineIndex = hoveredCharIndex - lineRange.location
+    
+    guard let hoveredChar = (line as NSString).substringFromIndex(hoveredCharLineIndex).characters.first
+      where hoveredChar != "\n" && hoveredChar != "'" && hoveredChar != "\"" && hoveredCharLineIndex > 0 else {
+        return nil
+    }
+    
+    var podStartIndex = -1, podEndIndex = -1
+    
+    // Starting at the mouse location...
+    
+    // Iterate to the right of the text line in search of the first occurrence of a " or '
+    // →
+    let rightSideRange = NSRange(location: hoveredCharLineIndex, length: line.characters.count - hoveredCharLineIndex)
+    for (index, char) in (line as NSString).substringWithRange(rightSideRange).characters.enumerate() {
+      if char == "'" || char == "\"" {
+        podEndIndex = hoveredCharLineIndex + index
+        break
+      }
+    }
+    
+    // Iterate to the left of the text line search of the first occurence of a " or '
+    // ←
+    let leftSideRange = NSRange(location: 0, length: hoveredCharLineIndex)
+    for (index, char) in (line as NSString).substringWithRange(leftSideRange).characters.reverse().enumerate() {
+      if char == "'" || char == "\"" {
+        podStartIndex = hoveredCharLineIndex - index
+        break
+      }
+    }
+    
+    guard podStartIndex >= 0 && podEndIndex >= 0 &&
+      (line as NSString).substringWithRange(NSRange(location: 0, length: podStartIndex - 1)).trim().hasSuffix("pod") else {
+        return nil
+    }
+    
+    // We need to update the cursor to be inside the pod name so the `autoCompleteDelegate`
+    // gets the autocompletions from the `CPPodfileEditorViewController`
+    setSelectedRange(NSRange(location: hoveredCharIndex, length: 0))
+    
+    let podName = (line as NSString).substringWithRange(NSRange(location: podStartIndex, length: podEndIndex - podStartIndex))
+    guard let _ = autoCompleteDelegate.completions().indexOf({ ($0 as? String) == podName }) else {
+      return nil
+    }
+    
+    let podNameRange = NSRange(location: lineRange.location + podStartIndex, length: podEndIndex - podStartIndex)
+    return (podName, podNameRange)
+  }
+  
+  private func updateUnderlineStyle(forPodAtRange range: NSRange) {
+    textStorage?.beginEditing()
+    textStorage?.addAttributes([
+      NSUnderlineStyleAttributeName: NSNumber(integer: NSUnderlineStyle.StyleSingle.rawValue),
+      NSUnderlineColorAttributeName: CPFontAndColourGateKeeper().cpLinkRed
+      ], range: range)
+    textStorage?.endEditing()
+  }
+  
+  private func removeUnderlineStyle(forPodAtRange range: NSRange?) {
+    guard let range = range else { return }
+    
+    textStorage?.beginEditing()
+    textStorage?.removeAttribute(NSUnderlineStyleAttributeName, range: range)
+    textStorage?.endEditing()
+  }
+  
+  private func resetUnderlineStyles() {
+    removeUnderlineStyle(forPodAtRange: hoveredPodRange)
+    hoveredPodRange = nil
+    
+    removeUnderlineStyle(forPodAtRange: selectedPodRange)
+    selectedPodRange = nil
+  }
+  
+  private func showPodPopover(forPodWithName podName: String, atRange: NSRange) {
+    guard let window = window, let string = string,
+      let podURL = NSURL(string: "https://cocoapods.org/pods/\(podName)"),
+      let customCSSFilePath = NSBundle.mainBundle().resourcePath?.stringByAppendingString("/CocoaPods.css") else {
+        return
+    }
+    
+    optionClickPopover?.close()
+    
+    let webView = WebView(frame: NSRect(x: 0, y: 0, width: 320, height: 350))
+    webView.wantsLayer = true
+    webView.policyDelegate = self
+    webView.preferences.userStyleSheetEnabled = true
+    webView.preferences.userStyleSheetLocation = NSURL(fileURLWithPath: customCSSFilePath)
+    webView.mainFrame.loadRequest(NSURLRequest(URL: podURL))
+    
+    let popoverViewController = NSViewController()
+    popoverViewController.view = webView
+    
+    var podNameRect = firstRectForCharacterRange(atRange, actualRange: nil)
+    podNameRect = window.convertRectFromScreen(podNameRect)
+    podNameRect = convertRect(podNameRect, toView: nil)
+    podNameRect.size.width = 1
+    
+    // We use the width of the range starting at the beginning of the line until the middle of the pod name
+    // as the x coordinate for the popover (the popover is always centered to the pod name, no matter
+    // where the option-click/three finger tap occurred)
+    let lineRange = (string as NSString).lineRangeForRange(atRange)
+    let startToMiddlePodRange =
+      NSRange(location: lineRange.location,
+              length: atRange.location - lineRange.location + atRange.length / 2 + (atRange.length % 2 == 0 ? 0 : 1))
+    podNameRect.origin.x = firstRectForCharacterRange(startToMiddlePodRange, actualRange: nil).width
+
+    let popover = NSPopover()
+    popover.contentViewController = popoverViewController
+    popover.behavior = .Transient
+    popover.delegate = self
+    popover.showRelativeToRect(podNameRect, ofView: self, preferredEdge: .MaxY)
+    
+    optionClickPopover = popover
+  }
+  
+  public override func shouldChangeTextInRange(affectedCharRange: NSRange, replacementString: String?) -> Bool {
+    resetUnderlineStyles()
+    return super.shouldChangeTextInRange(affectedCharRange, replacementString: replacementString)
+  }
+}
+
+// MARK: - NSPopoverDelegate
+extension SMLTextView: NSPopoverDelegate {
+
+  public func popoverWillClose(notification: NSNotification) {
+    resetUnderlineStyles()
+  }
+}
+
+// MARK: - WebPolicyDelegate
+extension SMLTextView: WebPolicyDelegate {
+  
+  public func webView(webView: WebView!, decidePolicyForNavigationAction actionInformation: [NSObject : AnyObject]!,
+                      request: NSURLRequest!, frame: WebFrame!, decisionListener listener: WebPolicyDecisionListener!) {
+    if let _ = actionInformation?[WebActionElementKey],
+      let externalURL = actionInformation[WebActionOriginalURLKey] as? NSURL {
+      // An action has ocurred (link click): redirect the user to the browser
+      listener.ignore()
+      NSWorkspace.sharedWorkspace().openURL(externalURL)
+    } else {
+      // Loading the CocoaPods pod page: accept
+      listener.use()
+    }
+  }
+}
+

--- a/app/CocoaPods/String+Extensions.swift
+++ b/app/CocoaPods/String+Extensions.swift
@@ -1,0 +1,5 @@
+extension String {
+  func trim() -> String {
+    return stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+  }
+}

--- a/app/CocoaPods/Supporting Files/CocoaPods.css
+++ b/app/CocoaPods/Supporting Files/CocoaPods.css
@@ -1,0 +1,8 @@
+nav.navbar.navbar-static-top {
+  min-height: 1px!important;
+  height: 8px!important;
+}
+
+nav.navbar.navbar-static-top > section {
+  visibility: hidden!important
+}


### PR DESCRIPTION
This PR implements #302 - "Allow option clicking on a pod":

- Option click/three finger tap on a pod name to show the popover with the cocoapods pod page
- Hovering the pod name with the option key down will also underline the pod's name
- Clicking on any link inside the popover's `WebView` will redirect the user to the browser
- Custom CSS to remove cocoapods.org global menu from the popover's `WebView`

How it looks:
![option click popover](https://cloud.githubusercontent.com/assets/1943188/15263616/9574f3e8-1963-11e6-85c8-dd505c8078ce.png)

Would love to get some feedback.