### PR TITLE
Adjust the colour of the app icon during dev #trivial

### DIFF
--- a/app/CocoaPods.xcodeproj/project.pbxproj
+++ b/app/CocoaPods.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		C907783E1CE68CCE00A7E235 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C907783C1CE68CCE00A7E235 /* String+Extensions.swift */; };
 		C90778401CE68CD900A7E235 /* CocoaPods.css in Resources */ = {isa = PBXBuildFile; fileRef = C907783F1CE68CD900A7E235 /* CocoaPods.css */; };
 		D69F9D731CE679CF00ACB1BF /* CPPodFileWindowViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69F9D721CE679CF00ACB1BF /* CPPodFileWindowViewController.swift */; };
+		D6B4AFBC1CED11AF0056F22B /* CPDebuggerCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = D6B4AFBB1CED11AF0056F22B /* CPDebuggerCheck.m */; };
 		E70998471C49AB5B00229507 /* Podfile.plist in Resources */ = {isa = PBXBuildFile; fileRef = E70998461C49AB5B00229507 /* Podfile.plist */; };
 		E72E9FDA1C6E328C00A8705B /* CPStringArrayToSentenceValueTransformerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72E9FD91C6E328C00A8705B /* CPStringArrayToSentenceValueTransformerSpec.swift */; };
 		E72E9FDC1C6E38B400A8705B /* CocoaPodsTests-Bridging-Header.h in Sources */ = {isa = PBXBuildFile; fileRef = E72E9FDB1C6E379200A8705B /* CocoaPodsTests-Bridging-Header.h */; };
@@ -306,6 +307,8 @@
 		C907783C1CE68CCE00A7E235 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		C907783F1CE68CD900A7E235 /* CocoaPods.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = CocoaPods.css; sourceTree = "<group>"; };
 		D69F9D721CE679CF00ACB1BF /* CPPodFileWindowViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPPodFileWindowViewController.swift; sourceTree = "<group>"; };
+		D6B4AFBA1CED11AF0056F22B /* CPDebuggerCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPDebuggerCheck.h; sourceTree = "<group>"; };
+		D6B4AFBB1CED11AF0056F22B /* CPDebuggerCheck.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPDebuggerCheck.m; sourceTree = "<group>"; };
 		E70998461C49AB5B00229507 /* Podfile.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Podfile.plist; path = "Syntax Definitions/Podfile.plist"; sourceTree = "<group>"; };
 		E72E9FD91C6E328C00A8705B /* CPStringArrayToSentenceValueTransformerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CPStringArrayToSentenceValueTransformerSpec.swift; sourceTree = "<group>"; };
 		E72E9FDB1C6E379200A8705B /* CocoaPodsTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CocoaPodsTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -434,6 +437,7 @@
 		51165E211A17AFF500DCFC94 /* CocoaPods */ = {
 			isa = PBXGroup;
 			children = (
+				D6B4AFB91CED11A30056F22B /* Utilities */,
 				6061C54F1CCBA9000063C44A /* CHANGELOG.md */,
 				60E693B11C4A52AF0058DF5F /* App */,
 				331188541BEBCB0F00272793 /* CLI Integrations */,
@@ -705,6 +709,15 @@
 				C907783B1CE68CCE00A7E235 /* SMLTextView+OptionClickPopover.swift */,
 			);
 			name = Extensions;
+			sourceTree = "<group>";
+		};
+		D6B4AFB91CED11A30056F22B /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				D6B4AFBA1CED11AF0056F22B /* CPDebuggerCheck.h */,
+				D6B4AFBB1CED11AF0056F22B /* CPDebuggerCheck.m */,
+			);
+			name = Utilities;
 			sourceTree = "<group>";
 		};
 		FA16FACB1C14475200DC3791 /* URL Handling */ = {
@@ -1030,6 +1043,7 @@
 			files = (
 				6038B78C1C28B57600359F3B /* CPMetadataTableViewDataSource.swift in Sources */,
 				600CACE91C4669030048F2F3 /* CPStringArrayToSentenceValueTransformer.m in Sources */,
+				D6B4AFBC1CED11AF0056F22B /* CPDebuggerCheck.m in Sources */,
 				E72E9FDF1C6E4DC900A8705B /* CPTestHelper.swift in Sources */,
 				510F09751C0A73B800F40F2B /* CPRubyErrors.m in Sources */,
 				603F7F1E1C1DE895006C2571 /* CPMenuVisiblityDirector.swift in Sources */,

--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -1,5 +1,6 @@
 #import "CPAppDelegate.h"
 #import "CPCLIToolInstallationController.h"
+#import "CPDebuggerCheck.h"
 #import "CPHomeWindowController.h"
 #import "CPReflectionServiceProtocol.h"
 #import "CocoaPods-Swift.h"
@@ -22,6 +23,7 @@
   PFMoveToApplicationsFolderIfNecessary();
   [self startURLService];
   [self checkForBirthday];
+  [self checkForDebugger];
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification;
@@ -105,10 +107,21 @@
   return _homeWindowController;
 }
 
+- (void)checkForDebugger
+{
+  if ([CPDebuggerCheck isInDebugger]) {
+    NSApplication *app = [NSApplication sharedApplication];
+    NSImage *appIcon = [app applicationIconImage];
+
+    [app setApplicationIconImage:[self imageWithHueAdjust:appIcon colorValue:@(400)]];
+  }
+}
+
 #pragma mark - Easter Eggs
 
 - (void)checkForBirthday
 {
+
   NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitMonth | NSCalendarUnitDay fromDate:[NSDate date]];
   if (components.month == 8 && components.day == 13) {
     NSApplication *app = [NSApplication sharedApplication];
@@ -119,12 +132,16 @@
 
 - (NSImage *)editionColoredImage:(NSImage *)image
 {
+  return [self imageWithHueAdjust:image colorValue:@(365.375)];
+}
+
+- (NSImage *)imageWithHueAdjust:(NSImage *)image colorValue:(NSNumber *)colorValue
+{
   CIImage *inputImage = [[CIImage alloc] initWithData:image.TIFFRepresentation];
 
   CIFilter *hueAdjust = [CIFilter filterWithName:@"CIHueAdjust"];
   [hueAdjust setValue: inputImage forKey: @"inputImage"];
 
-  NSNumber *colorValue = @(365.375);
   [hueAdjust setValue:colorValue forKey: @"inputAngle"];
 
   CIImage *outputImage = hueAdjust.outputImage;

--- a/app/CocoaPods/CPDebuggerCheck.h
+++ b/app/CocoaPods/CPDebuggerCheck.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface CPDebuggerCheck : NSObject
+
++ (BOOL)isInDebugger;
+
+@end

--- a/app/CocoaPods/CPDebuggerCheck.m
+++ b/app/CocoaPods/CPDebuggerCheck.m
@@ -1,0 +1,40 @@
+#import "CPDebuggerCheck.h"
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/sysctl.h>
+#include <stdlib.h>
+
+// https://developer.apple.com/library/mac/qa/qa1361/_index.html
+// http://www.coredump.gr/articles/ios-anti-debugging-protections-part-2/
+
+static int is_debugger_present(void)
+{
+    int name[4];
+    struct kinfo_proc info;
+    size_t info_size = sizeof(info);
+
+    info.kp_proc.p_flag = 0;
+
+    name[0] = CTL_KERN;
+    name[1] = KERN_PROC;
+    name[2] = KERN_PROC_PID;
+    name[3] = getpid();
+
+    if (sysctl(name, 4, &info, &info_size, NULL, 0) == -1) {
+        perror("sysctl");
+        NSLog(@"unknown error");
+        return 0;
+    }
+
+    return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
+
+@implementation CPDebuggerCheck
+
++ (BOOL)isInDebugger
+{
+    return is_debugger_present();
+}
+
+@end


### PR DESCRIPTION
Detect when a debugger is attached and change
the colour of the app icon. Not quite sure how the rotation of the hue works, ideally I guess we'd want to use #5AA6E8

![image](https://cloud.githubusercontent.com/assets/1333960/15375436/f8138ae6-1d46-11e6-9b7c-a98492705a16.png)

