### PR TITLE
Added option to remove Command-Line Tool again (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * Fix error when trying to create a new Podfile from an xcodeproj with spaces  
   [marcboquet](https://github.com/marcboquet)
   [#337](https://github.com/CocoaPods/CocoaPods-app/pull/337)
+  
+* Added option to remove installed Command-Line Tool again (#338)  
+  [Buju77](https://github.com/Buju77)
+  [#344](https://github.com/CocoaPods/CocoaPods-app/pull/344)  
 
 ## [1.0.0](https://github.com/CocoaPods/CocoaPods-app/releases/tag/1.0.0)
    [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#100-2016-05-10)

--- a/app/CocoaPods/Base.lproj/MainMenu.xib
+++ b/app/CocoaPods/Base.lproj/MainMenu.xib
@@ -14,6 +14,7 @@
         <customObject id="Voe-Tx-rLC" userLabel="App Delegate" customClass="CPAppDelegate">
             <connections>
                 <outlet property="documentController" destination="Qtz-kf-riq" id="Zl6-hS-hbl"/>
+                <outlet property="removeCommandLineToolMenuItem" destination="JNe-tW-Tp9" id="gqu-Cm-DzJ"/>
             </connections>
         </customObject>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
@@ -57,6 +58,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="installBinstubIfNecessary:" target="-1" id="1aC-DY-EQL"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Remove the Command-Line Tool…" hidden="YES" id="JNe-tW-Tp9">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="removeBinstubIfNecessary:" target="Voe-Tx-rLC" id="nAW-bJ-hUa"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Check for Updates…" id="6Sx-7e-VkP">
@@ -111,6 +118,9 @@
                                 </connections>
                             </menuItem>
                         </items>
+                        <connections>
+                            <outlet property="delegate" destination="Voe-Tx-rLC" id="ahL-fs-Ah5"/>
+                        </connections>
                     </menu>
                 </menuItem>
                 <menuItem title="File" id="dMs-cI-mzQ">

--- a/app/CocoaPods/CLI Integrations/CPCLIToolInstallationController.h
+++ b/app/CocoaPods/CLI Integrations/CPCLIToolInstallationController.h
@@ -12,29 +12,34 @@ extern NSString * const kCPCLIToolInstalledToDestinationsKey;
 /// Checks if binstub is not installed yet and is not configured to not request the
 /// user for installation again (`kCPRequestCLIToolInstallationAgainKey`).
 ///
-/// Returns whether or not installation should be performed.
+/// @returns whether or not installation should be performed.
 
 - (BOOL)shouldInstallBinstubIfNecessary;
 
 /// Only performs the installation if it's not installed yet and is not configured to not request the
 /// user for installation again (`kCPRequestCLIToolInstallationAgainKey`).
 ///
-/// Returns whether or not installation has been performed.
+/// @return Whether or not installation has been performed.
 ///
 - (BOOL)installBinstubIfNecessary;
 
 /// Always tries to perform the installation, unless the user cancels an overwrite.
 ///
-/// Returns whether or not installation has been performed.
+/// @return Whether or not installation has been performed.
 ///
 - (BOOL)installBinstub;
 
+/// Tries to remove the already installed binstub. Will only remove the binstub when it was installed using the app.
+///
+/// @return Whether uninstall was successful or not.
+///
+- (BOOL)removeBinstub;
 
 /// Allows the user to choose a different destination than the suggested destination.
 ///
 /// Updates the `destinationURL` if the user chooses a new one.
 ///
-/// Returns whether or not a destination was chosen or if the user cancelled.
+/// @returns whether or not a destination was chosen or if the user cancelled.
 ///
 - (BOOL)runModalDestinationChangeSavePanel;
 
@@ -43,5 +48,7 @@ extern NSString * const kCPCLIToolInstalledToDestinationsKey;
 
 - (BOOL)binstubAlreadyExists;
 
+/// Returns `YES` if binstub was installed using this controller.
+- (BOOL)hasInstalledBinstubBefore;
 
 @end

--- a/app/CocoaPods/CPAppDelegate.m
+++ b/app/CocoaPods/CPAppDelegate.m
@@ -8,10 +8,11 @@
 #import <Quartz/Quartz.h>
 @import LetsMove;
 
-@interface CPAppDelegate ()
+@interface CPAppDelegate () <NSMenuDelegate>
 @property (nonatomic, strong) CPHomeWindowController *homeWindowController;
 @property (strong) NSXPCConnection *reflectionService;
 @property (strong) URLHandler *urlHandler;
+@property (weak) IBOutlet NSMenuItem *removeCommandLineToolMenuItem;
 @end
 
 @implementation CPAppDelegate
@@ -80,11 +81,26 @@
   return YES;
 }
 
+#pragma mark - NSMenuDelegate
+
+- (void)menuWillOpen:(NSMenu *)menu
+{
+  // check if we should show or hide the "Remove CLI Tools" menu item
+  if ([menu.title isEqualToString:@"CocoaPods"]) {
+    self.removeCommandLineToolMenuItem.hidden = ![self.homeWindowController isBinstubAlreadyInstalled];
+  }
+}
+
 #pragma mark - Actions
 
 - (IBAction)installBinstubIfNecessary:(id)sender;
 {
     [self.homeWindowController installBinstub:sender];
+}
+
+- (IBAction)removeBinstubIfNecessary:(id)sender
+{
+  [self.homeWindowController removeBinstub:sender];
 }
 
 - (IBAction)showHomeWindow:(id)sender;

--- a/app/CocoaPods/CPHomeWindowController.h
+++ b/app/CocoaPods/CPHomeWindowController.h
@@ -2,7 +2,13 @@
 
 @interface CPHomeWindowController : NSWindowController <NSDraggingDestination>
 
+/// Checks if binstab is already installed
+- (BOOL)isBinstubAlreadyInstalled;
+
 /// Forces the installation of the binstub
 - (IBAction)installBinstub:(id)sender;
+
+/// Removes alraedy installed binstub
+- (IBAction)removeBinstub:(id)sender;
 
 @end

--- a/app/CocoaPods/Supporting Files/Localizable.strings
+++ b/app/CocoaPods/Supporting Files/Localizable.strings
@@ -9,6 +9,9 @@
 "INSTALL_CLI_WARNING_INFORMATIVE_TEXT" = "The tool was likely installed from the Terminal by running the “gem install cocoapods” command. \n\nIf you wish to keep that installation intact, be sure to choose an alternate filename or directory (preferably in your Terminal PATH) for this tool.\n\nNote that you can always revert by running the aforementioned Terminal command again.";
 "INSTALL_CLI_WARNING_OVERWRITE" = "Overwrite";
 
+"UNINSTALL_CLI_WARNING_MESSAGE_TEXT" = "Are you really sure you want to remove the Command-Line Tool?";
+"UNINSTALL_CLI_REMOVE" = "Yes, Remove!";
+
 "WORKSPACE_GENERATED_NOTIFICATION_TITLE" = "Pod Workspace Ready";
 "WORKSPACE_FAILED_GENERATION_NOTIFICATION_TITLE" = "Something Went Wrong";
 


### PR DESCRIPTION
* moved creation of CLIToolInstallationController to init of CPHomeWindowController (was in windowDidLoad)

Finally i had some time to put this together. This is my first commit ever for an mac app, so I have no idea if its correct ;-)

~~And I have no idea about the privileged access to remove the binstub how to do it ;)~~ (Solved)