### PR TITLE
Attempt a fix for #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Master
 
+* Fix for app launch crash
+  [orta](https://github.com/orta)
+  [#323](https://github.com/CocoaPods/CocoaPods-app/issue/323)
+
 * Pod version completion
   [flufff42](https://github.com/flufff42)
   [#313](https://github.com/CocoaPods/CocoaPods-app/pull/313)

--- a/app/CPReflectionService/RBObject+CocoaPods.rb
+++ b/app/CPReflectionService/RBObject+CocoaPods.rb
@@ -88,7 +88,7 @@ module Pod
       sources_manager.all.map { |source|
         { source.name => source.url }
 
-      }.reduce &:merge
+      }.reduce(&:merge).select { |key, value| key.is_a?(String) && value.is_a?(String) }
     end
 
     def self.lockfile_version(path)


### PR DESCRIPTION
I really am grasping at straws here WRT the launch crasher #323 

``` swift
    reflector.allCocoaPodsSources { sources, error in
>      let unordered_sources =  sources.map { CPSourceRepo(name: $0.0, address: $0.1) }
      self.allRepos = unordered_sources.sort(self.cocoaPodsSpecSort)
```

This line crashes, which can only really happen if there isn't both strings in the dictionary as keys and values. 
