### PR TITLE
[Travis-CI] Fix Travis CI build

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,21 +1,21 @@
-has_app_changes = !modified_files.grep(/app/).empty?
+has_app_changes = !git.modified_files.grep(/app/).empty?
 
-if pr_body.length < 5
+if github.pr_body.length < 5
   fail "Please provide a summary in the Pull Request description"
 end
 
-declared_trivial = pr_title.include?("#trivial") || pr_body.include?("#trivial") || !has_app_changes
-if !modified_files.include?("CHANGELOG.md") && !declared_trivial
+declared_trivial = github.pr_title.include?("#trivial") || github.pr_body.include?("#trivial") || !has_app_changes
+if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
   fail "Please include a CHANGELOG entry to credit yourself! \nYou can find it at [CHANGELOG.md](https://github.com/CocoaPods/CocoaPods-app/blob/master/CHANGELOG.md)."
 
-  pr = env.request_source.pr_json
+  pr = github.pr_json
   markdown <<-MARKDOWN
 Here's an example of your CHANGELOG entry:
 
 ```
 * #{pr.title}  
-  [#{pr_author}](https://github.com/#{pr_author})
-  [##{pr.number}](https://github.com/#{pr.base.repo.full_name}/pull/#{pr.number})
+  [#{pr.user.login}](#{pr.user.html_url})
+  [##{pr.number}](#{pr.html_url})
 ```
 MARKDOWN
 end

--- a/Rakefile
+++ b/Rakefile
@@ -141,7 +141,7 @@ BZR_VERSION = '2.6.0'
 BZR_URL = "https://launchpad.net/bzr/2.6/2.6.0/+download/bzr-#{BZR_VERSION}.tar.gz"
 
 MERCURIAL_VERSION = '3.3.3'
-MERCURIAL_URL = "http://mercurial.selenic.com/release/mercurial-#{MERCURIAL_VERSION}.tar.gz"
+MERCURIAL_URL = "https://www.mercurial-scm.org/release/mercurial-#{MERCURIAL_VERSION}.tar.gz"
 
 # see https://help.github.com/articles/caching-your-github-password-in-git/
 GIT_CREDENTIALS_URL = "https://github-media-downloads.s3.amazonaws.com/osx/git-credential-osxkeychain"


### PR DESCRIPTION
Update the download location for Mercurial.
This is to try to fix the Travis-CI build.
Using the URL used in the [Homebrew formula for Mercurial](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mercurial.rb)